### PR TITLE
Make `AzureContainerInstanceJob` accessible from `prefect_azure`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Added
-
+- Made `AzureContainerInstanceJob` accessible directly from the `prefect_azure` module. 
 ### Changed
 
 ### Deprecated

--- a/prefect_azure/__init__.py
+++ b/prefect_azure/__init__.py
@@ -5,12 +5,14 @@ from .credentials import (  # noqa
     AzureMlCredentials,
     AzureContainerInstanceCredentials,
 )
+from .container_instance import AzureContainerInstanceJob  # noqa
 
 __all__ = [
     "AzureBlobStorageCredentials",
     "AzureCosmosDbCredentials",
     "AzureMlCredentials",
     "AzureContainerInstanceCredentials",
+    "AzureContainerInstanceJob",
 ]
 
 __version__ = _version.get_versions()["version"]

--- a/prefect_azure/container_instance.py
+++ b/prefect_azure/container_instance.py
@@ -1,11 +1,11 @@
 """
 <span class="badge-api experimental"/>
-Integrations with the Azure Container Instances.
+Integrations with the Azure Container Instances service.
 Note this module is experimental. The interfaces within may change without notice.
 
-The infrastructure block in the module is ideally configured via the Prefect UI and run
-via a Prefect agent, but it can be called directly as demonstrated in the following
-examples.
+The `AzureContainerInstanceJob` infrastructure block in this module is ideally
+configured via the Prefect UI and run via a Prefect agent, but it can be called directly
+as demonstrated in the following examples.
 
 Examples:
     Run a command using an Azure Container Instances container.

--- a/tests/test_aci_infrastructure.py
+++ b/tests/test_aci_infrastructure.py
@@ -613,3 +613,9 @@ def test_output_streaming(
     # and should not be written twice, and one has a broken timestamp so should
     # not be written
     assert mock_write_call.call_count == 6
+
+
+def test_block_accessible_in_module_toplevel():
+    # will raise an exception and fail the test if `AzureContainerInstanceJob`
+    # is not accessible directly from `prefect_azure`
+    from prefect_azure import AzureContainerInstanceJob  # noqa


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to prefect-azure 🎉!

We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Run `pre-commit install && pre-commit run --all` for linting.

Happy engineering!
-->

<!-- Include an overview here -->
We removed prefect_azure.container_instance from `entrypoints`, but the class was is exported from the `prefect_azure` module, it does not end up in Prefect's registry. 

This PR adds `AzureContainerInstanceJob` to `__init__.py` so the infrastructure block is available directly from `prefect_azure`.


### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
-->
- Try to create a deployment with an `AzureContainerInstanceJob` block as the deployment's infrastructure. 
- Observe that it fails with the message `KeyError: "No class found for dispatch key 'azure-container-instance-job' in registry for type 'Block'."`
- Apply the change to `__init__.py` and observe that the deployment now succeeds.
### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "Closes #<ISSUE_NUMBER>"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect-azure/issues/new/choose) first.
- [X] This pull request includes tests or only affects documentation. 
- [X] Summarized PR's changes in [CHANGELOG.md](https://github.com/PrefectHQ/prefect-azure/blob/main/CHANGELOG.md)
