### PR TITLE
Fix `AzureContainerInstanceJob` private Docker registry usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Added
- 
+
 ### Changed
 
 ### Deprecated
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed handling of private Docker image registries - [#54](https://github.com/PrefectHQ/prefect-azure/pull/54)
 ### Security
 
 ## 0.2.2

--- a/prefect_azure/container_instance.py
+++ b/prefect_azure/container_instance.py
@@ -390,12 +390,14 @@ class AzureContainerInstanceJob(Infrastructure):
             self.resource_group_name
         )
 
-        image_registry_credential = (
-            ImageRegistryCredential(
-                server=self.image_registry.registry_url,
-                username=self.image_registry.username,
-                password=self.image_registry.password.get_secret_value(),
-            )
+        image_registry_credentials = (
+            [
+                ImageRegistryCredential(
+                    server=self.image_registry.registry_url,
+                    username=self.image_registry.username,
+                    password=self.image_registry.password.get_secret_value(),
+                )
+            ]
             if self.image_registry
             else None
         )
@@ -411,7 +413,7 @@ class AzureContainerInstanceJob(Infrastructure):
             containers=[container],
             os_type=OperatingSystemTypes.linux,
             restart_policy=ContainerGroupRestartPolicy.never,
-            image_registry_credentials=image_registry_credential,
+            image_registry_credentials=image_registry_credentials,
             subnet_ids=subnet_ids,
         )
 


### PR DESCRIPTION
When creating a container group that uses a private container registry, the Azure SDK expects a `List[ImageRegistryCredential]` even if you only use a single registry. However, the ACI block currently tries to pass a lone `ImageRegistryCredential` instead of a list, causing an error like this:

```
azure.core.exceptions.HttpResponseError: (InaccessibleImage) The image 'myiamge.azurecr.io/my_flow:2' in container group 'container-group-id' is not accessible. Please check the image and registry credential.
```

This PR fixes the problem by passing a `List[ImageRegistryCredential]` to the Azure SDK instead of a single `ImageRegistryCredential`.

I have tested this change on Azure to verify that it works. It has also been tested and verified by a user currently running it in production.

### Example/Steps to QA
* Create an Azure Container Instances Block that uses a private Docker registry.
* Observe that flows fail to launch due to an exception caused by the incorrect parameter type.
* Apply the change in this PR.
* Observe that flows now launch as expected.

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "Closes #<ISSUE_NUMBER>"
	- **N/A** - This fix seems too small to need an issue, but I am happy to create one if necessary.
- [x] This pull request includes tests or only affects documentation.
- [x] Summarized PR's changes in [CHANGELOG.md](https://github.com/PrefectHQ/prefect-azure/blob/main/CHANGELOG.md)
