### PR TITLE
Use secure ACI environment variable for PREFECT_API_KEY

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Added
- 
+
 ### Changed
 
 ### Deprecated
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed handling of private Docker image registries - [#54](https://github.com/PrefectHQ/prefect-azure/pull/54)
 ### Security
 
 ## 0.2.2

--- a/prefect_azure/container_instance.py
+++ b/prefect_azure/container_instance.py
@@ -390,12 +390,14 @@ class AzureContainerInstanceJob(Infrastructure):
             self.resource_group_name
         )
 
-        image_registry_credential = (
-            ImageRegistryCredential(
-                server=self.image_registry.registry_url,
-                username=self.image_registry.username,
-                password=self.image_registry.password.get_secret_value(),
-            )
+        image_registry_credentials = (
+            [
+                ImageRegistryCredential(
+                    server=self.image_registry.registry_url,
+                    username=self.image_registry.username,
+                    password=self.image_registry.password.get_secret_value(),
+                )
+            ]
             if self.image_registry
             else None
         )
@@ -411,7 +413,7 @@ class AzureContainerInstanceJob(Infrastructure):
             containers=[container],
             os_type=OperatingSystemTypes.linux,
             restart_policy=ContainerGroupRestartPolicy.never,
-            image_registry_credentials=image_registry_credential,
+            image_registry_credentials=image_registry_credentials,
             subnet_ids=subnet_ids,
         )
 


### PR DESCRIPTION
The Azure Container Instances Python SDK uses an `EnvironmentVariable` class for passing values that will be set as environment variables when a container starts. `EnvironmentVariable`'s constructor offers two options for setting environment variable values:
* `value`: The environment variable will be shown verbatim in logs and in the Azure Portal.
* `secure_value`: The environment variable will be obscured in logs and in the Azure Portal.

This PR:
* Adds an `ENV_SECRETS` constant containing a list of environment variables that should be treated as secure when creating ACI containers. For now, the list has a single entry: "PREFECT_API_KEY".
* Updates `AzureContainerInstanceJob` to use `secure_value` when creating an `EnvironmentVariable` instance for any environment variable in the `ENV_SECRETS` list.



<!-- 
Thanks for opening a pull request to prefect-azure 🎉!

We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Run `pre-commit install && pre-commit run --all` for linting.

Happy engineering!
-->

<!-- Include an overview here -->

<!-- Link to issue -->
Closes #

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
-->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "Closes #<ISSUE_NUMBER>"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect-azure/issues/new/choose) first.
- [ ] This pull request includes tests or only affects documentation.
- [ ] Summarized PR's changes in [CHANGELOG.md](https://github.com/PrefectHQ/prefect-azure/blob/main/CHANGELOG.md)
