### PR TITLE
Use secure ACI environment variable for PREFECT_API_KEY

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Updated the Container Instance Job block to treat `PREFECT_API_KEY` as a secure environment variable - [#57](https://github.com/PrefectHQ/prefect-azure/pull/57)
+
 ### Deprecated
 
 ### Removed
@@ -18,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed handling of private Docker image registries - [#54](https://github.com/PrefectHQ/prefect-azure/pull/54)
+
 ### Security
 
 ## 0.2.2

--- a/prefect_azure/container_instance.py
+++ b/prefect_azure/container_instance.py
@@ -87,6 +87,9 @@ ACI_DEFAULT_CPU = 1.0
 ACI_DEFAULT_MEMORY = 1.0
 ACI_DEFAULT_GPU = 0.0
 DEFAULT_CONTAINER_ENTRYPOINT = "/opt/prefect/entrypoint.sh"
+# environment variables that ACI should treat as secure variables so they
+# won't appear in logs
+ENV_SECRETS = ["PREFECT_API_KEY"]
 
 
 class ContainerGroupProvisioningState(str, Enum):
@@ -328,9 +331,12 @@ class AzureContainerInstanceJob(Infrastructure):
 
         # setup container environment variables
         environment = [
-            EnvironmentVariable(name=k, value=v)
+            EnvironmentVariable(name=k, secure_value=v)
+            if k in ENV_SECRETS
+            else EnvironmentVariable(name=k, value=v)
             for (k, v) in self._get_environment().items()
         ]
+
         # all container names in a resource group must be unique
         container_name = str(uuid.uuid4())
         container_resource_requirements = self._configure_container_resources()

--- a/tests/test_aci_infrastructure.py
+++ b/tests/test_aci_infrastructure.py
@@ -1,6 +1,6 @@
 import json
 import uuid
-from typing import List, Tuple, Union
+from typing import Dict, List, Tuple, Union
 from unittest.mock import MagicMock, Mock
 
 import dateutil.parser
@@ -8,9 +8,13 @@ import pytest
 from anyio.abc import TaskStatus
 from azure.core.exceptions import HttpResponseError
 from azure.identity import ClientSecretCredential
-from azure.mgmt.containerinstance.models import ImageRegistryCredential
+from azure.mgmt.containerinstance.models import (
+    EnvironmentVariable,
+    ImageRegistryCredential,
+)
 from azure.mgmt.resource import ResourceManagementClient
 from prefect.infrastructure.docker import DockerRegistry
+from prefect.settings import get_current_settings
 from pydantic import SecretStr
 
 import prefect_azure.container_instance
@@ -658,3 +662,39 @@ def test_registry_credentials(container_instance_block, mock_aci_client, monkeyp
     assert registry_object.username == registry.username
     assert registry_object.password == registry.password.get_secret_value()
     assert registry_object.server == registry.registry_url
+
+
+def test_secure_environment_variables(
+    container_instance_block, mock_aci_client, monkeypatch
+):
+    # setup environment containing an API key we want to keep secret
+    base_env: Dict[str, str] = get_current_settings().to_environment_variables(
+        exclude_unset=True
+    )
+    base_env["PREFECT_API_KEY"] = "my-api-key"
+
+    base_env_call = Mock(return_value=base_env)
+    monkeypatch.setattr(container_instance_block, "_base_environment", base_env_call)
+
+    mock_container_constructor = Mock()
+    monkeypatch.setattr(
+        prefect_azure.container_instance, "Container", mock_container_constructor
+    )
+
+    container_instance_block.run()
+
+    mock_container_constructor.assert_called_once()
+    (_, kwargs) = mock_container_constructor.call_args
+    env_variables_parameter: List = kwargs.get("environment_variables")
+
+    api_key_aci_env_variable: List[EnvironmentVariable] = list(
+        filter(lambda v: v.name == "PREFECT_API_KEY", env_variables_parameter)
+    )
+
+    # ensure the env variable made it into the list of env variables set in the
+    # ACI container
+    assert len(api_key_aci_env_variable) == 1
+    assert api_key_aci_env_variable[0].name == "PREFECT_API_KEY"
+    # ensure that `secure_value` was used instead of `value`
+    assert api_key_aci_env_variable[0].value is None
+    assert api_key_aci_env_variable[0].secure_value == "my-api-key"


### PR DESCRIPTION
The Azure Container Instances Python SDK uses an `EnvironmentVariable` class for passing values that will be set as environment variables when a container starts. `EnvironmentVariable`'s constructor offers two options for setting environment variable values:
* `value`: The environment variable will be shown verbatim in logs and in the Azure Portal.
* `secure_value`: The environment variable will be obscured in logs and in the Azure Portal.

This PR:
* Adds an `ENV_SECRETS` constant containing a list of environment variables that should be treated as secure when creating ACI containers. For now, the list has a single entry: "PREFECT_API_KEY".
* Updates `AzureContainerInstanceJob` to use `secure_value` when creating an `EnvironmentVariable` instance for any environment variable in the `ENV_SECRETS` list.
* Adds a test to ensure that secrets use `secure_value` as expected.

Motivation: A Prefect cloud customer using the ACI block in production said this change would be appreciated because it will help ensure their Prefect API key remains confidential. 

### Example
If you run a flow using ACI with the current version of the block, and look at the container's environment variables in the Azure Portal while the flow is running, you will see `PREFECT_API_KEY` displayed openly (I blurred it manually here to keep my key private):
<img width="453" alt="Screen Shot 2022-11-30 at 2 02 57 PM" src="https://user-images.githubusercontent.com/228762/204892253-4b29cc2d-558e-479a-9444-088c90080f94.jpg">


Ideally, we'd like to avoid this. After applying the changes in this PR and re-running the flow, the Azure Portal shows that the container received the `PREFECT_API_KEY` environment variable, but leaves the display value blank:

<img width="453" alt="Screen Shot 2022-11-30 at 2 26 07 PM" src="https://user-images.githubusercontent.com/228762/204891225-2c0210ff-039e-4bbc-881b-50e15b1b2c80.png">

The API key is still available _inside_ the container, so the change in this PR has no impact on flow runs; it only impacts visibility of the env variable outside the container.


### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "Closes #<ISSUE_NUMBER>"
	- **this enhancement seems too minor to warrant a separate issue, but I am happy to create one if needed.
- [x] This pull request includes tests or only affects documentation.
- [x] Summarized PR's changes in [CHANGELOG.md](https://github.com/PrefectHQ/prefect-azure/blob/main/CHANGELOG.md)
