### PR TITLE
Add `AzureContainerInstanceJob.kill` for flow run cancellation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added flow run cancellation support to the `AzureContainerInstanceJob` block - [#58](https://github.com/PrefectHQ/prefect-azure/pull/57)
+
 ### Changed
 
 - Updated the Container Instance Job block to treat `PREFECT_API_KEY` as a secure environment variable - [#57](https://github.com/PrefectHQ/prefect-azure/pull/57)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Added flow run cancellation support to the `AzureContainerInstanceJob` block - [#58](https://github.com/PrefectHQ/prefect-azure/pull/57)
+- Added flow run cancellation support to the `AzureContainerInstanceJob` block - [#58](https://github.com/PrefectHQ/prefect-azure/pull/58)
 
 ### Changed
 

--- a/prefect_azure/container_instance.py
+++ b/prefect_azure/container_instance.py
@@ -615,6 +615,8 @@ class AzureContainerInstanceJob(Infrastructure):
                 )
             await anyio.sleep(self.task_watch_poll_interval)
 
+        self.logger.info(f"{self._log_prefix}: Container deleted.")
+
     def _get_container(self, container_group: ContainerGroup) -> Container:
         """
         Extracts the job container from a container group.

--- a/prefect_azure/container_instance.py
+++ b/prefect_azure/container_instance.py
@@ -649,7 +649,7 @@ class AzureContainerInstanceJob(Infrastructure):
         client: ContainerInstanceManagementClient,
         container_group: ContainerGroup,
         max_lines: int = 100,
-    ) -> Union[str, None]:
+    ) -> str:
         """
         Gets the most container logs up to a given maximum.
 

--- a/prefect_azure/container_instance.py
+++ b/prefect_azure/container_instance.py
@@ -311,6 +311,7 @@ class AzureContainerInstanceJob(Infrastructure):
     async def kill(self, container_group_name: str, grace_seconds: int = 30):
         """
         Kill a flow running in an ACI container group.
+
         Args:
             container_group_name: The container group name yielded by
                 `AzureContainerInstanceJob.run`.

--- a/prefect_azure/container_instance.py
+++ b/prefect_azure/container_instance.py
@@ -334,12 +334,12 @@ class AzureContainerInstanceJob(Infrastructure):
                 resource_group_name=self.resource_group_name,
                 container_group_name=container_group_name,
             )
-        except ResourceNotFoundError:
+        except ResourceNotFoundError as exc:
             # the container group no longer exists, so there's nothing to cancel
             raise InfrastructureNotFound(
                 f"Cannot stop ACI job: container group {container_group_name} "
                 "no longer exists."
-            )
+            ) from exc
 
         # get the container state to check if the container has terminated
         container = self._get_container(container_group)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-prefect>=2.0.0
+prefect>=2.7.0
 azure_mgmt_containerinstance>=10.0
 azure_identity>=1.10
-azure-mgmt-resource>=21.1
+azure-mgmt-resource>=21.2

--- a/tests/test_aci_infrastructure.py
+++ b/tests/test_aci_infrastructure.py
@@ -699,8 +699,8 @@ def test_secure_environment_variables(
     # ensure that `secure_value` was used instead of `value`
     assert api_key_aci_env_variable[0].value is None
     assert api_key_aci_env_variable[0].secure_value == "my-api-key"
-    
-    
+
+
 async def test_kill_deletes_container_group(
     container_instance_block, mock_aci_client, mock_running_container_group, monkeypatch
 ):


### PR DESCRIPTION
This PR adds a `kill` method to `AzureContainerInstanceJob` to support flow run cancellation added in Prefect 2.7.0. See the PR in the `prefect` repository for further detail: https://github.com/PrefectHQ/prefect/pull/7666

Small updates to exception handling, log messages and type annotations were added to other parts of `AzureContainerInstanceJob` to make it more resilient, particularly when making Azure log fetch API calls that fail sporadically when running an underpowered container under heavy load.

<!-- 
Thanks for opening a pull request to prefect-azure 🎉!

We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Run `pre-commit install && pre-commit run --all` for linting.

Happy engineering!
-->

<!-- Include an overview here -->
## Example 
The only visible effect of these updates is that the user can click the big red Cancel button on the Prefect >= 2.7.0 Flow Run page:

<img width="103" alt="Screen Shot 2022-12-01 at 10 51 50 PM" src="https://user-images.githubusercontent.com/228762/205211129-34e6affd-2b6e-480b-b3fe-95ec1b34558b.png">

After confirming they are sure they want to cancel the flow run, the user can check the Azure Portal to confirm that was once a happily running flow:

<img width="1100" alt="Screen Shot 2022-12-01 at 10 54 16 PM" src="https://user-images.githubusercontent.com/228762/205211766-54734bac-2c37-4336-a26d-ada728b5439d.png">

has now vanished, with its container group and all containers deleted:

<img width="1100" alt="Screen Shot 2022-12-01 at 10 54 42 PM" src="https://user-images.githubusercontent.com/228762/205211849-fcef1005-8b72-4258-8814-44ac2e54cb38.png">

Closes #59.

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "Closes #<ISSUE_NUMBER>"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect-azure/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] Summarized PR's changes in [CHANGELOG.md](https://github.com/PrefectHQ/prefect-azure/blob/main/CHANGELOG.md)
