### PR TITLE
Add default azure credential

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pycqa/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
       - id: isort
         language_version: python3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added `AzureContainerInstanceCredentials.credential_kwargs` - [#69](https://github.com/PrefectHQ/prefect-azure/pull/69)
+
 ### Changed
+
+- Made `AzureContainerInstanceCredentials` args, `tenant_id`, `client_id`, `client_secret` default to None - [#69](https://github.com/PrefectHQ/prefect-azure/pull/69)
+- `AzureContainerInstanceCredentials` is no longer required in `AzureContainerInstanceJob` - [#69](https://github.com/PrefectHQ/prefect-azure/pull/69)
 
 ### Deprecated
 

--- a/prefect_azure/container_instance.py
+++ b/prefect_azure/container_instance.py
@@ -144,7 +144,13 @@ class AzureContainerInstanceJob(Infrastructure):
     type: Literal["container-instance-job"] = Field(
         default="container-instance-job", description="The slug for this task type."
     )
-    aci_credentials: AzureContainerInstanceCredentials
+    aci_credentials: AzureContainerInstanceCredentials = Field(
+        default_factory=AzureContainerInstanceCredentials,
+        description=(
+            "Credentials for Azure Container Instances; "
+            "if not provided will attempt to use DefaultAzureCredentials."
+        ),
+    )
     resource_group_name: str = Field(
         default=...,
         title="Azure Resource Group Name",

--- a/prefect_azure/container_instance.py
+++ b/prefect_azure/container_instance.py
@@ -140,6 +140,7 @@ class AzureContainerInstanceJob(Infrastructure):
     _block_type_name = "Azure Container Instance Job"
     _logo_url = "https://images.ctfassets.net/gm98wzqotmnx/6AiQ6HRIft8TspZH7AfyZg/39fd82bdbb186db85560f688746c8cdd/azure.png?h=250"  # noqa
     _description = "Run tasks using Azure Container Instances. Note this block is experimental. The interface may change without notice."  # noqa
+    _documentation_url = "https://prefecthq.github.io/prefect-azure/container_instance/#prefect_azure.container_instance.AzureContainerInstanceJob"  # noqa
 
     type: Literal["container-instance-job"] = Field(
         default="container-instance-job", description="The slug for this task type."

--- a/prefect_azure/credentials.py
+++ b/prefect_azure/credentials.py
@@ -443,6 +443,7 @@ class AzureContainerInstanceCredentials(Block):
                 "If any of `client_id`, `tenant_id`, or `client_secret` are provided, "
                 "all must be provided."
             )
+        return values
 
     def get_container_client(self, subscription_id: str):
         """

--- a/prefect_azure/credentials.py
+++ b/prefect_azure/credentials.py
@@ -412,13 +412,33 @@ class AzureContainerInstanceCredentials(Block):
     _logo_url = "https://images.ctfassets.net/gm98wzqotmnx/6AiQ6HRIft8TspZH7AfyZg/39fd82bdbb186db85560f688746c8cdd/azure.png?h=250"  # noqa
 
     client_id: Optional[str] = Field(
-        default=None, title="Client ID", description="The service principal client ID."
+        default=None,
+        title="Client ID",
+        description=(
+            "The service principal client ID. "
+            "If none of client_id, tenant_id, and client_secret are provided, "
+            "will use DefaultAzureCredential; else will need to provide all three to "
+            "use ClientSecretCredential."
+        ),
     )
     tenant_id: Optional[str] = Field(
-        default=None, title="Tenant ID", description="The service principal tenant ID."
+        default=None,
+        title="Tenant ID",
+        description=(
+            "The service principal tenant ID."
+            "If none of client_id, tenant_id, and client_secret are provided, "
+            "will use DefaultAzureCredential; else will need to provide all three to "
+            "use ClientSecretCredential."
+        ),
     )
     client_secret: Optional[SecretStr] = Field(
-        default=None, description="The service principal client secret."
+        default=None,
+        description=(
+            "The service principal client secret."
+            "If none of client_id, tenant_id, and client_secret are provided, "
+            "will use DefaultAzureCredential; else will need to provide all three to "
+            "use ClientSecretCredential."
+        ),
     )
     credential_kwargs: Dict[str, Any] = Field(
         default_factory=dict,

--- a/prefect_azure/credentials.py
+++ b/prefect_azure/credentials.py
@@ -89,6 +89,7 @@ class AzureBlobStorageCredentials(Block):
 
     _block_type_name = "Azure Blob Storage Credentials"
     _logo_url = "https://images.ctfassets.net/gm98wzqotmnx/6AiQ6HRIft8TspZH7AfyZg/39fd82bdbb186db85560f688746c8cdd/azure.png?h=250"  # noqa
+    _documentation_url = "https://prefecthq.github.io/prefect-azure/credentials/#prefect_azure.credentials.AzureBlobStorageCredentials"  # noqa
 
     connection_string: Optional[SecretStr] = Field(
         default=None,
@@ -267,6 +268,7 @@ class AzureCosmosDbCredentials(Block):
 
     _block_type_name = "Azure Cosmos DB Credentials"
     _logo_url = "https://images.ctfassets.net/gm98wzqotmnx/6AiQ6HRIft8TspZH7AfyZg/39fd82bdbb186db85560f688746c8cdd/azure.png?h=250"  # noqa
+    _documentation_url = "https://prefecthq.github.io/prefect-azure/credentials/#prefect_azure.credentials.AzureCosmosDbCredentials"  # noqa
 
     connection_string: SecretStr = Field(
         default=..., description="Includes the authorization information required."
@@ -386,6 +388,7 @@ class AzureMlCredentials(Block):
 
     _block_type_name = "AzureML Credentials"
     _logo_url = "https://images.ctfassets.net/gm98wzqotmnx/6AiQ6HRIft8TspZH7AfyZg/39fd82bdbb186db85560f688746c8cdd/azure.png?h=250"  # noqa
+    _documentation_url = "https://prefecthq.github.io/prefect-azure/credentials/#prefect_azure.credentials.AzureMlCredentials"  # noqa
 
     tenant_id: str = Field(
         default=...,
@@ -457,6 +460,7 @@ class AzureContainerInstanceCredentials(Block):
 
     _block_type_name = "Azure Container Instance Credentials"
     _logo_url = "https://images.ctfassets.net/gm98wzqotmnx/6AiQ6HRIft8TspZH7AfyZg/39fd82bdbb186db85560f688746c8cdd/azure.png?h=250"  # noqa
+    _documentation_url = "https://prefecthq.github.io/prefect-azure/credentials/#prefect_azure.credentials.AzureContainerInstanceCredentials"  # noqa
 
     client_id: Optional[str] = Field(
         default=None,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,27 @@ from unittest.mock import MagicMock
 
 import pytest
 from azure.core.exceptions import ResourceExistsError
-from prefect.testing.utilities import AsyncMock
+from prefect.testing.utilities import AsyncMock, prefect_test_harness
+
+
+@pytest.fixture(scope="session", autouse=True)
+def prefect_db():
+    """
+    Sets up test harness for temporary DB during test runs.
+    """
+    with prefect_test_harness():
+        yield
+
+
+@pytest.fixture(autouse=True)
+def reset_object_registry():
+    """
+    Ensures each test has a clean object registry.
+    """
+    from prefect.context import PrefectObjectRegistry
+
+    with PrefectObjectRegistry():
+        yield
 
 
 class AsyncIter:

--- a/tests/test_aci_infrastructure.py
+++ b/tests/test_aci_infrastructure.py
@@ -864,6 +864,11 @@ def test_azure_container_instance_credentials_no_args():
     assert isinstance(credentials._create_credential(), DefaultAzureCredential)
 
 
+def test_azure_container_instance_credentials_insufficient_args():
+    with pytest.raises(ValueError, match="If any of `client_id`"):
+        AzureContainerInstanceCredentials(tenant_id="tenant_id")
+
+
 def test_azure_container_instance_credentials_random_kwargs():
     credentials = AzureContainerInstanceCredentials(
         credential_kwargs={"exclude_powershell_credential": True}


### PR DESCRIPTION
<!-- Thanks for contributing 🎉! Please ensure the title neatly summarizes the proposed changes. -->

<!-- Overview -->

Make AzureContainerInstanceCredentials optional by using default_factory. Also make tenant_id, client_id, client_secret default to None so default_factory can initialize.

Closes https://github.com/PrefectHQ/prefect-azure/issues/68

### Example
<!-- A code blurb is best. Changes to features should include an example that is executable by a new user. -->

### Screenshots
<!--
Any relevant screenshots
  - The updated docs page from `mkdocs serve`.
  - Output from running the example.
  - Service integration test results.
-->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] References any related issue by including "Closes #<Issue Number>" or "Closes <Issue URL>".
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect-azure/issues/new/choose) first.
- [x] Includes tests or only affects documentation.
- [x] Passes `pre-commit` checks.
  - Run `pre-commit install && pre-commit run --all` locally for formatting and linting.
- [x] Includes screenshots of documentation updates.
  - Run `mkdocs serve` view documentation locally.
- [x] Summarizes PR's changes in [CHANGELOG.md](https://github.com/PrefectHQ/prefect-azure/blob/main/CHANGELOG.md)
