### PR TITLE
Make connection string optional for blob

### DIFF
--- a/prefect_azure/credentials.py
+++ b/prefect_azure/credentials.py
@@ -1,12 +1,12 @@
 """Credential classes used to perform authenticated interactions with Azure"""
 
 import functools
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Dict, Optional
 
-from azure.identity import ClientSecretCredential
+from azure.identity import ClientSecretCredential, DefaultAzureCredential
 from azure.mgmt.containerinstance import ContainerInstanceManagementClient
 from azure.mgmt.resource import ResourceManagementClient
-from pydantic import Field, SecretStr
+from pydantic import Field, SecretStr, root_validator
 
 try:
     from azure.cosmos import CosmosClient
@@ -90,9 +90,35 @@ class AzureBlobStorageCredentials(Block):
     _block_type_name = "Azure Blob Storage Credentials"
     _logo_url = "https://images.ctfassets.net/gm98wzqotmnx/6AiQ6HRIft8TspZH7AfyZg/39fd82bdbb186db85560f688746c8cdd/azure.png?h=250"  # noqa
 
-    connection_string: SecretStr = Field(
-        default=..., description="Includes the authorization information required."
+    connection_string: Optional[SecretStr] = Field(
+        default=None,
+        description=(
+            "If account_url is not provided, " "the connection string to authenticate."
+        ),
     )
+    account_url: Optional[str] = Field(
+        default=None,
+        description=(
+            "If a connection string is not provided, "
+            "the URL to the Blob Storage account; will use "
+            "DefaultAzureCredential to authenticate."
+        ),
+    )
+
+    @root_validator
+    def check_connection_string_or_account_url(
+        cls, values: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        """
+        Checks that either a connection string or account URL is provided, not both.
+        """
+        has_account_url = values.get("account_url") is not None
+        has_conn_str = values.get("connection_string") is not None
+        if not bool(has_account_url ^ has_conn_str):
+            raise ValueError(
+                "Must provide either a connection string or account URL, but not both."
+            )
+        return values
 
     @_raise_help_msg("blob_storage")
     def get_client(self) -> "BlobServiceClient":
@@ -121,6 +147,12 @@ class AzureBlobStorageCredentials(Block):
             asyncio.run(example_get_client_flow())
             ```
         """
+        if self.connection_string is None:
+            return BlobServiceClient(
+                account_url=self.account_url,
+                credential=DefaultAzureCredential(),
+            )
+
         return BlobServiceClient.from_connection_string(
             self.connection_string.get_secret_value()
         )
@@ -158,6 +190,14 @@ class AzureBlobStorageCredentials(Block):
             asyncio.run(example_get_blob_client_flow())
             ```
         """
+        if self.connection_string is None:
+            return BlobClient(
+                account_url=self.account_url,
+                container_name=container,
+                credential=DefaultAzureCredential(),
+                blob_name=blob,
+            )
+
         blob_client = BlobClient.from_connection_string(
             self.connection_string.get_secret_value(), container, blob
         )
@@ -195,6 +235,13 @@ class AzureBlobStorageCredentials(Block):
             asyncio.run(example_get_container_client_flow())
             ```
         """
+        if self.connection_string is None:
+            return ContainerClient(
+                account_url=self.account_url,
+                container_name=container,
+                credential=DefaultAzureCredential(),
+            )
+
         container_client = ContainerClient.from_connection_string(
             self.connection_string.get_secret_value(), container
         )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,27 @@ from unittest.mock import MagicMock
 
 import pytest
 from azure.core.exceptions import ResourceExistsError
-from prefect.testing.utilities import AsyncMock
+from prefect.testing.utilities import AsyncMock, prefect_test_harness
+
+
+@pytest.fixture(scope="session", autouse=True)
+def prefect_db():
+    """
+    Sets up test harness for temporary DB during test runs.
+    """
+    with prefect_test_harness():
+        yield
+
+
+@pytest.fixture(autouse=True)
+def reset_object_registry():
+    """
+    Ensures each test has a clean object registry.
+    """
+    from prefect.context import PrefectObjectRegistry
+
+    with PrefectObjectRegistry():
+        yield
 
 
 class AsyncIter:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -146,6 +146,15 @@ def blob_connection_string():
     return "AccountName=account_name;AccountKey=account_key"
 
 
+@pytest.fixture
+def account_url(monkeypatch):
+    monkeypatch.setattr(
+        "azure.storage.blob._shared.base_client_async.AsyncStorageBearerTokenCredentialPolicy",  # noqa
+        MagicMock(),
+    )
+    return "account_url"
+
+
 class CosmosClientMock(MagicMock):
     def from_connection_string(connection_string):
         return CosmosClientMock()

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -1,5 +1,6 @@
 from unittest.mock import MagicMock
 
+import pytest
 from azure.storage.blob import BlobClient, BlobServiceClient, ContainerClient
 from conftest import CosmosClientMock
 from prefect import flow
@@ -45,6 +46,40 @@ def test_get_blob_client(blob_connection_string):
         return client
 
     client = test_flow()
+    assert isinstance(client, BlobClient)
+    client.container_name == "container"
+    client.blob_name == "blob"
+
+
+def test_get_service_client_either_error():
+    with pytest.raises(ValueError, match="either a connection string or"):
+        AzureBlobStorageCredentials().get_client()
+
+
+def test_get_service_client_both_error():
+    with pytest.raises(ValueError, match="not both"):
+        AzureBlobStorageCredentials(
+            connection_string="connection_string", account_url="account"
+        ).get_client()
+
+
+def test_get_service_client_no_conn_str():
+    client = AzureBlobStorageCredentials(account_url="account").get_client()
+    assert isinstance(client, BlobServiceClient)
+
+
+def test_get_blob_container_client_no_conn_str():
+    client = AzureBlobStorageCredentials(account_url="account").get_container_client(
+        "container"
+    )
+    assert isinstance(client, ContainerClient)
+    client.container_name == "container"
+
+
+def test_get_blob_client_no_conn_str():
+    client = AzureBlobStorageCredentials(account_url="account").get_blob_client(
+        "container", "blob"
+    )
     assert isinstance(client, BlobClient)
     client.container_name == "container"
     client.blob_name == "blob"

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -63,21 +63,21 @@ def test_get_service_client_both_error():
         ).get_client()
 
 
-def test_get_service_client_no_conn_str():
-    client = AzureBlobStorageCredentials(account_url="account").get_client()
+def test_get_service_client_no_conn_str(account_url):
+    client = AzureBlobStorageCredentials(account_url=account_url).get_client()
     assert isinstance(client, BlobServiceClient)
 
 
-def test_get_blob_container_client_no_conn_str():
-    client = AzureBlobStorageCredentials(account_url="account").get_container_client(
+def test_get_blob_container_client_no_conn_str(account_url):
+    client = AzureBlobStorageCredentials(account_url=account_url).get_container_client(
         "container"
     )
     assert isinstance(client, ContainerClient)
     client.container_name == "container"
 
 
-def test_get_blob_client_no_conn_str():
-    client = AzureBlobStorageCredentials(account_url="account").get_blob_client(
+def test_get_blob_client_no_conn_str(account_url):
+    client = AzureBlobStorageCredentials(account_url=account_url).get_blob_client(
         "container", "blob"
     )
     assert isinstance(client, BlobClient)


### PR DESCRIPTION
<!-- Thanks for contributing 🎉! Please ensure the title neatly summarizes the proposed changes. -->

<!-- Overview -->

Use default azure credential for blob storage credentials.

Closes https://github.com/PrefectHQ/prefect-azure/issues/70

### Example
<!-- A code blurb is best. Changes to features should include an example that is executable by a new user. -->

### Screenshots
<!--
Any relevant screenshots
  - The updated docs page from `mkdocs serve`.
  - Output from running the example.
  - Service integration test results.
-->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] References any related issue by including "Closes #<Issue Number>" or "Closes <Issue URL>".
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect-azure/issues/new/choose) first.
- [x] Includes tests or only affects documentation.
- [x] Passes `pre-commit` checks.
  - Run `pre-commit install && pre-commit run --all` locally for formatting and linting.
- [x] Includes screenshots of documentation updates.
  - Run `mkdocs serve` view documentation locally.
- [x] Summarizes PR's changes in [CHANGELOG.md](https://github.com/PrefectHQ/prefect-azure/blob/main/CHANGELOG.md)
