### PR TITLE
Extended blob_storage_list kwargs to mimic underlying ContainerClient.list_blobs signature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Extended `blob_storage_list` kwargs to mimic underlying azure `ContainerClient.list_blobs()` signature
+
 ### Deprecated
 
 ### Removed

--- a/prefect_azure/blob_storage.py
+++ b/prefect_azure/blob_storage.py
@@ -1,6 +1,6 @@
 """Tasks for interacting with Azure Blob Storage"""
 import uuid
-from typing import TYPE_CHECKING, List
+from typing import TYPE_CHECKING, List, Union
 
 if TYPE_CHECKING:
     from azure.storage.blob import BlobProperties
@@ -123,12 +123,22 @@ async def blob_storage_upload(
 async def blob_storage_list(
     container: str,
     blob_storage_credentials: "AzureBlobStorageCredentials",
+    name_starts_with: str = None,
+    include: Union[str, List[str]] = None,
+    **kwargs
 ) -> List["BlobProperties"]:
     """
     List objects from a given Blob Storage container.
     Args:
         container: Name of the Blob Storage container to retrieve from.
         blob_storage_credentials: Credentials to use for authentication with Azure.
+        name_starts_with: Filters the results to return only blobs whose names
+            begin with the specified prefix.
+        include: Specifies one or more additional datasets to include in the response.
+            Options include: 'snapshots', 'metadata', 'uncommittedblobs', 'copy',
+            'deleted', 'deletedwithversions', 'tags', 'versions', 'immutabilitypolicy',
+            'legalhold'.
+        **kwargs: Addtional kwargs passed to `ContainerClient.list_blobs()`
     Returns:
         A `list` of `dict`s containing metadata about the blob.
     Example:
@@ -159,6 +169,11 @@ async def blob_storage_list(
     async with blob_storage_credentials.get_container_client(
         container
     ) as container_client:
-        blobs = [blob async for blob in container_client.list_blobs()]
+        blobs = [
+            blob
+            async for blob in container_client.list_blobs(
+                name_starts_with=name_starts_with, include=include, **kwargs
+            )
+        ]
 
     return blobs

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -62,8 +62,21 @@ class BlobStorageClientMethodsMock:
         mock_container[self.blob] = data
         return self.blob
 
-    def list_blobs(self):
-        return AsyncIter(range(5))
+    def list_blobs(self, name_starts_with=None, include=None, **kwargs):
+        sample_dicts = [
+            {"name": "fakefolder", "metadata": None},
+            *[{"name": f"fakefolder/file{i}", "metadata": None} for i in range(4)],
+        ]
+        if name_starts_with:
+            to_return = [
+                d for d in sample_dicts if d["name"].startswith(name_starts_with)
+            ]
+        else:
+            to_return = sample_dicts
+        if include:
+            for d in to_return:
+                d.update({"metadata": {"some_metadata": "true"}})
+        return AsyncIter(to_return)
 
     async def close(self):
         return None

--- a/tests/test_blob_storage.py
+++ b/tests/test_blob_storage.py
@@ -77,4 +77,37 @@ async def test_blob_storage_list_flow(blob_storage_credentials):
         )
 
     blobs = await blob_storage_list_flow()
-    assert blobs == list(range(5))
+    assert blobs == [
+        {"name": "fakefolder", "metadata": None},
+        *[{"name": f"fakefolder/file{i}", "metadata": None} for i in range(4)],
+    ]
+
+
+async def test_blob_storage_list_flow_with_name(blob_storage_credentials):
+    @flow
+    async def blob_storage_list_flow():
+        return await blob_storage_list(
+            container="prefect",
+            blob_storage_credentials=blob_storage_credentials,
+            name_starts_with="fakefolder/",
+        )
+
+    blobs = await blob_storage_list_flow()
+    assert blobs == [
+        {"name": f"fakefolder/file{i}", "metadata": None} for i in range(4)
+    ]
+
+
+async def test_blob_storage_list_flow_with_include(blob_storage_credentials):
+    @flow
+    async def blob_storage_list_flow():
+        return await blob_storage_list(
+            container="prefect",
+            blob_storage_credentials=blob_storage_credentials,
+            include=["metadata"],
+        )
+
+    blobs = await blob_storage_list_flow()
+    assert len(blobs) == 5
+    for blob_data in blobs:
+        assert isinstance(blob_data["metadata"], dict)


### PR DESCRIPTION
<!-- Thanks for contributing 🎉! Please ensure the title neatly summarizes the proposed changes. -->

<!-- Overview -->
### Change summary
Currently unable to pass useful kwargs to the underlying` ContainerClient.list_blobs` method to perform actions such as filtering the blob name and returning additional metadata. 

This PR extends the functionality of the `blob_storage_list` function to pass these kwargs to the underlying method to achieve this capability


### Example
<!-- A code blurb is best. Changes to features should include an example that is executable by a new user. -->
```python
...
@flow
async def blob_storage_list_flow():
    return await blob_storage_list(
        container="prefect",
        blob_storage_credentials=blob_storage_credentials,
        name_starts_with="subfolder/anotherSubfolder"
        include=["metadata"],
    )
```
### Screenshots
<!--
Any relevant screenshots
  - The updated docs page from `mkdocs serve`.
  - Output from running the example.
  - Service integration test results.
-->
![image](https://user-images.githubusercontent.com/30913420/226000819-e6eda3a4-3155-40cc-a972-5302cef7a938.png)

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ x] References any related issue by including "Closes #<Issue Number>" or "Closes <Issue URL>".
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect-azure/issues/new/choose) first.
- [ x] Includes tests or only affects documentation.
- [ x] Passes `pre-commit` checks.
  - Run `pre-commit install && pre-commit run --all` locally for formatting and linting.
- [x ] Includes screenshots of documentation updates.
  - Run `mkdocs serve` view documentation locally.
- [x ] Summarizes PR's changes in [CHANGELOG.md](https://github.com/PrefectHQ/prefect-azure/blob/main/CHANGELOG.md)
