### PR TITLE
Add ACR Managed Identity Support to `AzureContainerInstanceJob`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added Azure Container Registry managed identity support to `AzureContainerInstanceJob`
+
 ### Changed
 
 - Extended `blob_storage_list` kwargs to mimic underlying azure `ContainerClient.list_blobs()` signature

--- a/prefect_azure/container_instance.py
+++ b/prefect_azure/container_instance.py
@@ -49,6 +49,18 @@ Examples:
         env={"PLANET": "earth"}
     )
     ```
+
+    Run a task that uses a private ACR registry with a managed identity
+    ```python
+    AzureContainerInstanceJob(
+        command=["echo", "hello $PLANET"],
+        image="my-registry.azurecr.io/my-image",
+        image_registry=ACRManagedIdentity(
+            registry_url="my-registry.azurecr.io",
+            identity="/my/managed/identity/123abc"
+        )
+    )
+    ```
 """
 import datetime
 import json

--- a/prefect_azure/container_instance.py
+++ b/prefect_azure/container_instance.py
@@ -218,7 +218,7 @@ class AzureContainerInstanceJob(Infrastructure):
         ]
     ] = Field(
         default=None,
-        Title="Container Registry (Optional)",
+        title="Image Registry (Optional)",
         description=(
             "To use any private container registry with a username and password, "
             "choose DockerRegistry. To use a private Azure Container Registry "

--- a/prefect_azure/container_instance.py
+++ b/prefect_azure/container_instance.py
@@ -85,7 +85,7 @@ from prefect.docker import get_prefect_image_name
 from prefect.exceptions import InfrastructureNotAvailable, InfrastructureNotFound
 from prefect.infrastructure.base import Infrastructure, InfrastructureResult
 from prefect.utilities.asyncutils import run_sync_in_worker_thread, sync_compatible
-from pydantic import Field, SecretStr
+from pydantic import BaseModel, Field, SecretStr
 from typing_extensions import Literal
 
 from prefect_azure.credentials import AzureContainerInstanceCredentials
@@ -122,6 +122,27 @@ class ContainerRunState(str, Enum):
 
     RUNNING = "Running"
     TERMINATED = "Terminated"
+
+
+class ACRManagedIdentity(BaseModel):
+    """
+    Use a Managed Identity to access Azure Container registry. Requires the
+    user-assigned managed identity be available to the ACI container group.
+    """
+
+    registry_url: str = Field(
+        default=...,
+        description=(
+            "The URL to the registry, such as myregistry.azurecr.io. Generally, 'http' "
+            "or 'https' can be omitted."
+        ),
+    )
+    identity: str = Field(
+        default=...,
+        description=(
+            "The user-assigned Azure Managed identity for the private registry."
+        ),
+    )
 
 
 class AzureContainerInstanceJobResult(InfrastructureResult):

--- a/prefect_azure/container_instance.py
+++ b/prefect_azure/container_instance.py
@@ -211,7 +211,20 @@ class AzureContainerInstanceJob(Infrastructure):
             "to the entrypoint as parameters."
         ),
     )
-    image_registry: Optional[prefect.infrastructure.docker.DockerRegistry] = None
+    image_registry: Optional[
+        Union[
+            prefect.infrastructure.docker.DockerRegistry,
+            ACRManagedIdentity,
+        ]
+    ] = Field(
+        default=None,
+        Title="Container Registry (Optional)",
+        description=(
+            "To use any private container registry with a username and password, "
+            "choose DockerRegistry. To use a private Azure Container Registry "
+            "with a managed identity, choose ACRManagedIdentity."
+        ),
+    )
     cpu: float = Field(
         title="CPU",
         default=ACI_DEFAULT_CPU,


### PR DESCRIPTION
Azure Container Registry offers two authentication options: username + password, and [managed identities](https://learn.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/overview). Many organizations prefer using managed identities to limit the scope of access to Azure resources. 

This PR Updates `AzureContainerInstanceJob` to add support for accessing private ACR registries with a managed identity via an `ACRManagedIdentity` base model. private registries authenticated via username + password still work as before via `DockerRegistry`. 

The changes in this PR allow a user to either select a `DockerRegistry` block, or set a URL and managed identity for an ACR registry, as shown below.

Closes #76 

### Screenshots
<img width="793" alt="Screenshot 2023-03-26 at 11 48 41 PM" src="https://user-images.githubusercontent.com/228762/227836405-dceb4e7c-5f47-42b4-9c56-5559b57361d9.png">

<img width="792" alt="Screenshot 2023-03-26 at 11 49 00 PM" src="https://user-images.githubusercontent.com/228762/227836413-d567af76-9495-4734-b7a5-0ce9dd602e4d.png">

Autogenerated docs from docstring:
<img width="962" alt="Screenshot 2023-03-27 at 12 00 57 AM" src="https://user-images.githubusercontent.com/228762/227838079-d961edc5-e4d5-4b4d-994e-514085c7b714.png">


### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] References any related issue by including "Closes #<Issue Number>" or "Closes <Issue URL>".
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect-azure/issues/new/choose) first.
- [x] Includes tests or only affects documentation.
- [x] Passes `pre-commit` checks.
- [x] Includes screenshots of documentation updates.
- [x] Summarizes PR's changes in [CHANGELOG.md](https://github.com/PrefectHQ/prefect-azure/blob/main/CHANGELOG.md)
