### PR TITLE
Add Azure Container Instances worker

### DIFF
--- a/prefect_azure/__init__.py
+++ b/prefect_azure/__init__.py
@@ -5,6 +5,7 @@ from .credentials import (  # noqa
     AzureMlCredentials,
     AzureContainerInstanceCredentials,
 )
+from .workers.container_instance import AzureContainerWorker  # noqa
 from .container_instance import AzureContainerInstanceJob  # noqa
 
 __all__ = [
@@ -13,6 +14,7 @@ __all__ = [
     "AzureMlCredentials",
     "AzureContainerInstanceCredentials",
     "AzureContainerInstanceJob",
+    "AzureContainerWorker",
 ]
 
 __version__ = _version.get_versions()["version"]

--- a/prefect_azure/workers/__init__.py
+++ b/prefect_azure/workers/__init__.py
@@ -1,0 +1,1 @@
+from .container_instance import AzureContainerWorker

--- a/prefect_azure/workers/container_instance.py
+++ b/prefect_azure/workers/container_instance.py
@@ -1,0 +1,862 @@
+import datetime
+import json
+import sys
+import time
+import uuid
+from enum import Enum
+from typing import Dict, List, Optional, Union
+
+import anyio
+import dateutil.parser
+from azure.core.exceptions import HttpResponseError, ResourceNotFoundError
+from azure.core.polling import LROPoller
+from azure.mgmt.containerinstance import ContainerInstanceManagementClient
+from azure.mgmt.containerinstance.models import Container, ContainerGroup, Logs
+from azure.mgmt.resource.resources.models import (
+    Deployment,
+    DeploymentExtended,
+    DeploymentMode,
+    DeploymentProperties,
+)
+from prefect import get_client
+from prefect.client.schemas import FlowRun
+from prefect.docker import get_prefect_image_name
+from prefect.exceptions import InfrastructureNotAvailable, InfrastructureNotFound
+from prefect.server.schemas.core import Flow
+from prefect.server.schemas.responses import DeploymentResponse
+from prefect.utilities.asyncutils import run_sync_in_worker_thread
+from prefect.workers.base import (
+    BaseJobConfiguration,
+    BaseVariables,
+    BaseWorker,
+    BaseWorkerResult,
+)
+from pydantic import Field, SecretStr
+
+from prefect_azure.credentials import AzureContainerInstanceCredentials
+
+ACI_DEFAULT_CPU = 1.0
+ACI_DEFAULT_MEMORY = 1.0
+ACI_DEFAULT_GPU = 0.0
+DEFAULT_CONTAINER_ENTRYPOINT = "/opt/prefect/entrypoint.sh"
+# environment variables that ACI should treat as secure variables so they
+# won't appear in logs
+ENV_SECRETS = ["PREFECT_API_KEY"]
+
+# The maximum time to wait for container group deletion before giving up and
+# moving on. Deletion is usually quick, so exceeding this timeout means something
+# has gone wrong and we should raise an exception to inform the user they should
+# check their Azure account for orphaned container groups.
+CONTAINER_GROUP_DELETION_TIMEOUT_SECONDS = 30
+
+_default_arm_template = """  
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#", 
+  "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "bicep",
+      "version": "0.5.6.12127",
+      "templateHash": "17016281914347876853"
+    }
+  },
+  "parameters": {
+    "location": {
+      "type": "string",
+      "defaultValue": "[resourceGroup().location]",
+      "metadata": {
+        "description": "Location for all resources."
+      }
+    },
+    "name": {
+        "type": "string",
+        "defaultValue": "cool-container-group",
+        "metadata": {
+          "description": "Container group name."
+      }
+    }
+  },
+  "resources": [
+    {
+      "type": "Microsoft.ContainerInstance/containerGroups",
+      "apiVersion": "2021-09-01",
+      "name": "[parameters('name')]",
+      "location": "[parameters('location')]",
+      "properties": {
+        "containers": [
+          {
+            "name": "{{ name }}",
+            "properties": {
+              "image": "{{ image }}",
+              "command": {{ command }},
+              "resources": {
+                "requests": {
+                  "cpu": 1,
+                  "memoryInGB": 0.5
+                } 
+              },
+              "environmentVariables": {{ env }}
+            }
+          }
+        ],
+        "osType": "Linux",
+        "restartPolicy": "Never"
+      }
+    }
+  ]
+}
+"""  # noqa
+
+
+class ContainerGroupProvisioningState(str, Enum):
+    """
+    Terminal provisioning states for ACI container groups. Per the Azure docs,
+    the states in this Enum are the only ones that can be relied on as dependencies.
+    """
+
+    SUCCEEDED = "Succeeded"
+    FAILED = "Failed"
+
+
+class ContainerRunState(str, Enum):
+    """
+    Terminal run states for ACI containers.
+    """
+
+    RUNNING = "Running"
+    TERMINATED = "Terminated"
+
+
+class AzureContainerJobConfiguration(BaseJobConfiguration):
+    image: Optional[str] = Field(
+        default_factory=get_prefect_image_name,
+        description=(
+            "The image to use for the Prefect container in the task. This value "
+            "defaults to a Prefect base image matching your local versions."
+        ),
+    )
+    resource_group_name: str = Field(
+        default=...,
+        title="Azure Resource Group Name",
+        description=(
+            "The name of the Azure Resource Group in which to run Prefect ACI tasks."
+        ),
+    )
+    subscription_id: SecretStr = Field(
+        default=...,
+        title="Azure Subscription ID",
+        description="The ID of the Azure subscription to create containers under.",
+    )
+    identities: Optional[List[str]] = Field(
+        title="Identities",
+        default=None,
+        description=(
+            "A list of user-assigned identities to associate with the container group. "
+            "The identities should be an ARM resource IDs in the form: "
+            "'/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}'."  # noqa
+        ),
+    )
+
+    entrypoint: Optional[str] = Field(
+        default=DEFAULT_CONTAINER_ENTRYPOINT,
+        description=(
+            "The entrypoint of the container you wish you run. This value "
+            "defaults to the entrypoint used by Prefect images and should only be "
+            "changed when using a custom image that is not based on an official "
+            "Prefect image. Any commands set on deployments will be passed "
+            "to the entrypoint as parameters."
+        ),
+    )
+    cpu: float = Field(
+        title="CPU",
+        default=ACI_DEFAULT_CPU,
+        description=(
+            "The number of virtual CPUs to assign to the task container. "
+            f"If not provided, a default value of {ACI_DEFAULT_CPU} will be used."
+        ),
+    )
+    gpu_count: Optional[int] = Field(
+        title="GPU Count",
+        default=None,
+        description=(
+            "The number of GPUs to assign to the task container. "
+            "If not provided, no GPU will be used."
+        ),
+    )
+    gpu_sku: Optional[str] = Field(
+        title="GPU SKU",
+        default=None,
+        description=(
+            "The Azure GPU SKU to use. See the ACI documentation for a list of "
+            "GPU SKUs available in each Azure region."
+        ),
+    )
+    memory: float = Field(
+        default=ACI_DEFAULT_MEMORY,
+        description=(
+            "The amount of memory in gigabytes to provide to the ACI task. Valid "
+            "amounts are specified in the Azure documentation. If not provided, a "
+            f"default value of  {ACI_DEFAULT_MEMORY} will be used unless present "
+            "on the task definition."
+        ),
+    )
+    subnet_ids: Optional[List[str]] = Field(
+        default=None,
+        title="Subnet IDs",
+        description="A list of Azure subnet IDs the container should be connected to.",
+    )
+    dns_servers: Optional[List[str]] = Field(
+        default=None,
+        title="DNS Servers",
+        description="A list of custom DNS Servers the container should use.",
+    )
+    stream_output: Optional[bool] = Field(
+        default=None,
+        description=(
+            "If `True`, logs will be streamed from the Prefect container to the local "
+            "console."
+        ),
+    )
+    env: Dict[str, Optional[str]] = Field(
+        title="Environment Variables",
+        default_factory=dict,
+        description=(
+            "Environment variables to provide to the task run. These variables are set "
+            "on the Prefect container at task runtime. These will not be set on the "
+            "task definition."
+        ),
+    )
+    aci_credentials: AzureContainerInstanceCredentials = Field(
+        description="The credentials to use to authenticate with Azure.",
+    )
+    # Execution settings
+    task_start_timeout_seconds: int = Field(
+        default=240,
+        description=(
+            "The amount of time to watch for the start of the ACI container. "
+            "before marking it as failed."
+        ),
+    )
+    task_watch_poll_interval: float = Field(
+        default=5.0,
+        description=(
+            "The number of seconds to wait between Azure API calls while monitoring "
+            "the state of an Azure Container Instances task."
+        ),
+    )
+    template: str = Field(
+        default=_default_arm_template,
+        description=(
+            "The ARM template to use for the ACI task. This template should be a "
+            "valid Azure Resource Manager template. The template should contain "
+            "the following parameters: `name`, `image`, `command`, and `env`. "
+        ),
+    )
+
+    def prepare_for_flow_run(
+        self,
+        flow_run: "FlowRun",
+        deployment: Optional["DeploymentResponse"] = None,
+        flow: Optional["Flow"] = None,
+    ):
+        """
+        Prepares the job configuration for a flow run.
+        """
+        self.template = (
+            self.template.replace("{{ name }}", str(uuid.uuid4()))
+            .replace("{{ image }}", self.image)
+            .replace("{{ env }}", self._get_json_environment())
+            .replace("{{ command }}", json.dumps(self.command))
+        )
+
+    def _get_json_environment(self):
+        env = {**self._base_environment(), **self.env}
+
+        azure_env = [
+            {"name": key, "secureValue": value}
+            if key in ENV_SECRETS
+            else {"name": key, "value": value}
+            for key, value in env.items()
+        ]
+        return json.dumps(azure_env)
+
+
+class AzureContainerVariables(BaseVariables):
+    image: Optional[str] = Field(
+        default_factory=get_prefect_image_name,
+        description=(
+            "The image to use for the Prefect container in the task. This value "
+            "defaults to a Prefect base image matching your local versions."
+        ),
+    )
+    resource_group_name: str = Field(
+        default=...,
+        title="Azure Resource Group Name",
+        description=(
+            "The name of the Azure Resource Group in which to run Prefect ACI tasks."
+        ),
+    )
+    subscription_id: SecretStr = Field(
+        default=...,
+        title="Azure Subscription ID",
+        description="The ID of the Azure subscription to create containers under.",
+    )
+    identities: Optional[List[str]] = Field(
+        title="Identities",
+        default=None,
+        description=(
+            "A list of user-assigned identities to associate with the container group. "
+            "The identities should be an ARM resource IDs in the form: "
+            "'/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}'."  # noqa
+        ),
+    )
+    entrypoint: Optional[str] = Field(
+        default=DEFAULT_CONTAINER_ENTRYPOINT,
+        description=(
+            "The entrypoint of the container you wish you run. This value "
+            "defaults to the entrypoint used by Prefect images and should only be "
+            "changed when using a custom image that is not based on an official "
+            "Prefect image. Any commands set on deployments will be passed "
+            "to the entrypoint as parameters."
+        ),
+    )
+    cpu: float = Field(
+        title="CPU",
+        default=ACI_DEFAULT_CPU,
+        description=(
+            "The number of virtual CPUs to assign to the task container. "
+            f"If not provided, a default value of {ACI_DEFAULT_CPU} will be used."
+        ),
+    )
+    gpu_count: Optional[int] = Field(
+        title="GPU Count",
+        default=None,
+        description=(
+            "The number of GPUs to assign to the task container. "
+            "If not provided, no GPU will be used."
+        ),
+    )
+    gpu_sku: Optional[str] = Field(
+        title="GPU SKU",
+        default=None,
+        description=(
+            "The Azure GPU SKU to use. See the ACI documentation for a list of "
+            "GPU SKUs available in each Azure region."
+        ),
+    )
+    memory: float = Field(
+        default=ACI_DEFAULT_MEMORY,
+        description=(
+            "The amount of memory in gigabytes to provide to the ACI task. Valid "
+            "amounts are specified in the Azure documentation. If not provided, a "
+            f"default value of  {ACI_DEFAULT_MEMORY} will be used unless present "
+            "on the task definition."
+        ),
+    )
+    aci_credentials: AzureContainerInstanceCredentials = Field(
+        description=("The credentials to use to authenticate with Azure."),
+    )
+    stream_output: Optional[bool] = Field(
+        default=None,
+        description=(
+            "If `True`, logs will be streamed from the Prefect container to the local "
+            "console."
+        ),
+    )
+    env: Dict[str, Optional[str]] = Field(
+        title="Environment Variables",
+        default_factory=dict,
+        description=(
+            "Environment variables to provide to the task run. These variables are set "
+            "on the Prefect container at task runtime. These will not be set on the "
+            "task definition."
+        ),
+    )
+    # Execution settings
+    task_start_timeout_seconds: int = Field(
+        default=240,
+        description=(
+            "The amount of time to watch for the start of the ACI container. "
+            "before marking it as failed."
+        ),
+    )
+    task_watch_poll_interval: float = Field(
+        default=5.0,
+        description=(
+            "The number of seconds to wait between Azure API calls while monitoring "
+            "the state of an Azure Container Instances task."
+        ),
+    )
+
+
+class AzureContainerWorkerResult(BaseWorkerResult):
+    """Contains information about the final state of a completed process"""
+
+
+class AzureContainerWorker(BaseWorker):
+    type = "azure-container-instance"
+    job_configuration = AzureContainerJobConfiguration
+    job_configuration_variables = AzureContainerVariables
+
+    async def verify_submitted_deployment(self, deployment: Deployment):
+        # TODO: Implement deployment verification for `AzureContainerWorker`
+        pass
+
+    async def run(
+        self,
+        flow_run: FlowRun,
+        configuration: AzureContainerJobConfiguration,
+        task_status: Optional[anyio.abc.TaskStatus] = None,
+    ):
+        run_start_time = datetime.datetime.now(datetime.timezone.utc)
+        prefect_client = get_client()
+
+        # Get the flow, so we can use its name in the container group name
+        # to make it easier to identify and debug.
+        flow = prefect_client.read_flow(flow_run.flow_id)
+        container_group_name = f"{flow.name}-{flow_run.id}"
+
+        self.logger.info(
+            f"{self._log_prefix}: Preparing to run command {configuration.command} "
+            f"in container  {self.image})..."
+        )
+
+        aci_client = configuration.aci_credentials.get_container_client(
+            configuration.subscription_id.get_secret_value()
+        )
+        resource_client = configuration.aci_credentials.get_resource_client(
+            configuration.subscription_id.get_secret_value()
+        )
+
+        # Add the entrypoint if provided. Creating an ACI container with a
+        # command overrides the container's built-in entrypoint. Prefect base images
+        # use entrypoint.sh as the entrypoint, so we need to add it back in to avoid
+        # breaking EXTRA_PIP_PACKAGES installation on container startup.
+        if configuration.entrypoint:
+            configuration.command = (
+                f"{configuration.entrypoint} {configuration.command}"
+            )
+
+        properties = DeploymentProperties(
+            mode=DeploymentMode.INCREMENTAL,
+            template=json.loads(configuration.template),
+            parameters={"name": {"value": container_group_name}},
+        )
+
+        deployment = Deployment(properties=properties)
+
+        try:
+            creation_status_poller = resource_client.deployments.begin_create_or_update(
+                resource_group_name=configuration.resource_group_name,
+                deployment_name=f"prefect-{container_group_name}",
+                parameters=deployment,
+            )
+
+            created_container_group = await run_sync_in_worker_thread(
+                self._wait_for_task_container_start,
+                configuration.resource_group_name,
+                container_group_name,
+                creation_status_poller,
+            )
+
+            if self._provisioning_succeeded(created_container_group):
+                self.logger.info(f"{self._log_prefix}: Running command...")
+                if task_status is not None:
+                    task_status.started(value=container_group_name)
+
+                status_code = await run_sync_in_worker_thread(
+                    self._watch_task_and_get_exit_code,
+                    aci_client,
+                    configuration,
+                    container_group_name,
+                    run_start_time,
+                )
+                self.logger.info(f"{self._log_prefix}: Completed command run.")
+            else:
+                raise RuntimeError(f"{self._log_prefix}: Container creation failed.")
+
+        finally:
+            if created_container_group:
+                await self._wait_for_container_group_deletion(
+                    aci_client, created_container_group
+                )
+
+        return AzureContainerWorkerResult(
+            identifier=created_container_group.name, status_code=status_code
+        )
+
+    async def kill(
+        self,
+        configuration: AzureContainerJobConfiguration,
+        container_group_name: str,
+        grace_seconds: int = CONTAINER_GROUP_DELETION_TIMEOUT_SECONDS,
+    ):
+        """
+        Kill a flow running in an ACI container group.
+
+        Args:
+            container_group_name: The container group name yielded by
+                `AzureContainerInstanceJob.run`.
+            grace_seconds: The number of seconds to wait for the container group to
+                terminate.
+        """
+        # ACI does not provide a way to specify grace period, but it gives
+        # applications ~30 seconds to gracefully terminate before killing
+        # a container group.
+        if grace_seconds != CONTAINER_GROUP_DELETION_TIMEOUT_SECONDS:
+            self.logger.warning(
+                f"{self._log_prefix}: Kill grace period of {grace_seconds}s requested, "
+                f"but ACI does not support grace period configuration."
+            )
+
+        aci_client = self.aci_credentials.get_container_client(
+            self.subscription_id.get_secret_value()
+        )
+
+        # get the container group to check that it still exists
+        try:
+            container_group = aci_client.container_groups.get(
+                resource_group_name=configuration.resource_group_name,
+                container_group_name=container_group_name,
+            )
+        except ResourceNotFoundError as exc:
+            # the container group no longer exists, so there's nothing to cancel
+            raise InfrastructureNotFound(
+                f"Cannot stop ACI job: container group {container_group_name} "
+                "no longer exists."
+            ) from exc
+
+        # get the container state to check if the container has terminated
+        container = self._get_container(container_group)
+        container_state = container.instance_view.current_state.state
+
+        # the container group needs to be deleted regardless of whether the container
+        # already terminated
+        await self._wait_for_container_group_deletion(aci_client, container_group)
+
+        # if the container had already terminated, raise an exception to let the agent
+        # know the flow was not cancelled
+        if container_state == ContainerRunState.TERMINATED:
+            raise InfrastructureNotAvailable(
+                f"Cannot stop ACI job: container group {container_group.name} exists, "
+                f"but container {container.name} has already terminated."
+            )
+
+    def _wait_for_task_container_start(
+        self,
+        client: ContainerInstanceManagementClient,
+        resource_group_name: str,
+        container_group_name: str,
+        creation_status_poller: LROPoller[DeploymentExtended],
+    ) -> Optional[ContainerGroup]:
+        """
+        Wait for the result of group and container creation.
+
+        Args:
+            creation_status_poller: Poller returned by the Azure SDK.
+
+        Raises:
+            RuntimeError: Raised if the timeout limit is exceeded before the
+            container starts.
+
+        Returns:
+            A `ContainerGroup` representing the current status of the group being
+            watched, or None if creation failed.
+        """
+        t0 = time.time()
+        timeout = self.task_start_timeout_seconds
+
+        while not creation_status_poller.done():
+            elapsed_time = time.time() - t0
+
+            if timeout and elapsed_time > timeout:
+                raise RuntimeError(
+                    (
+                        f"Timed out after {elapsed_time}s while watching waiting for "
+                        "container start."
+                    )
+                )
+            time.sleep(self.task_watch_poll_interval)
+
+        deployment = creation_status_poller.result()
+
+        provisioning_succeeded = deployment.properties.provisioning_state == "Succeeded"
+
+        if provisioning_succeeded:
+            return self._get_container_group(
+                client, resource_group_name, container_group_name
+            )
+        else:
+            return None
+
+    def _watch_task_and_get_exit_code(
+        self,
+        client: ContainerInstanceManagementClient,
+        configuration: AzureContainerJobConfiguration,
+        container_group: ContainerGroup,
+        run_start_time: datetime.datetime,
+    ) -> int:
+        """
+        Waits until the container finishes running and obtains its exit code.
+
+        Args:
+            client: An initialized Azure `ContainerInstanceManagementClient`
+            container_group: The `ContainerGroup` in which the container resides.
+
+        Returns:
+            An `int` representing the container's exit code.
+        """
+        status_code = -1
+        running_container = self._get_container(container_group)
+        current_state = running_container.instance_view.current_state.state
+
+        # get any logs the container has already generated
+        last_log_time = run_start_time
+        if self.stream_output:
+            last_log_time = self._get_and_stream_output(
+                client, container_group, last_log_time
+            )
+
+        # set exit code if flow run already finished:
+        if current_state == ContainerRunState.TERMINATED:
+            status_code = running_container.instance_view.current_state.exit_code
+
+        while current_state != ContainerRunState.TERMINATED:
+            try:
+                container_group = self._get_container_group(
+                    client,
+                    configuration.resource_group_name,
+                    container_group.name,
+                )
+            except ResourceNotFoundError:
+                self.logger.exception(
+                    f"{self._log_prefix}: Container group was deleted before flow run "
+                    "completed, likely due to flow cancellation."
+                )
+
+                # since the flow was cancelled, exit early instead of raising an
+                # exception
+                return status_code
+
+            container = self._get_container(container_group)
+            current_state = container.instance_view.current_state.state
+
+            if current_state == ContainerRunState.TERMINATED:
+                status_code = container.instance_view.current_state.exit_code
+                # break instead of waiting for next loop iteration because
+                # trying to read logs from a terminated container raises an exception
+                break
+
+            if self.stream_output:
+                last_log_time = self._get_and_stream_output(
+                    client, container_group, last_log_time
+                )
+
+            time.sleep(self.task_watch_poll_interval)
+
+        return status_code
+
+    async def _wait_for_container_group_deletion(
+        self,
+        aci_client: ContainerInstanceManagementClient,
+        container_group: ContainerGroup,
+    ):
+        self.logger.info(f"{self._log_prefix}: Deleting container...")
+
+        deletion_status_poller = await run_sync_in_worker_thread(
+            aci_client.container_groups.begin_delete,
+            resource_group_name=self.resource_group_name,
+            container_group_name=container_group.name,
+        )
+
+        t0 = time.time()
+        timeout = CONTAINER_GROUP_DELETION_TIMEOUT_SECONDS
+
+        while not deletion_status_poller.done():
+            elapsed_time = time.time() - t0
+
+            if timeout and elapsed_time > timeout:
+                raise RuntimeError(
+                    (
+                        f"Timed out after {elapsed_time}s while waiting for deletion of"
+                        f" container group {container_group.name}. To verify the group "
+                        "has been deleted, check the Azure Portal or run "
+                        f"az container show --name {container_group.name} --resource-group {self.resource_group_name}"  # noqa
+                    )
+                )
+            await anyio.sleep(self.task_watch_poll_interval)
+
+        self.logger.info(f"{self._log_prefix}: Container deleted.")
+
+    def _get_container(self, container_group: ContainerGroup) -> Container:
+        """
+        Extracts the job container from a container group.
+        """
+        return container_group.containers[0]
+
+    @staticmethod
+    def _get_container_group(
+        client: ContainerInstanceManagementClient,
+        resource_group_name: str,
+        container_group_name: str,
+    ) -> ContainerGroup:
+        """
+        Gets the container group from Azure.
+        """
+        return client.container_groups.get(
+            resource_group_name=resource_group_name,
+            container_group_name=container_group_name,
+        )
+
+    def _get_and_stream_output(
+        self,
+        client: ContainerInstanceManagementClient,
+        container_group: ContainerGroup,
+        last_log_time: datetime.datetime,
+    ) -> datetime.datetime:
+        """
+        Fetches logs output from the job container and writes all entries after
+        a given time to stderr.
+
+        Args:
+            client: An initialized `ContainerInstanceManagementClient`
+            container_group: The container group that holds the job container.
+            last_log_time: The timestamp of the last output line already streamed.
+
+        Returns:
+            The time of the most recent output line written by this call.
+        """
+        logs = self._get_logs(client, container_group)
+        return self._stream_output(logs, last_log_time)
+
+    def _get_logs(
+        self,
+        client: ContainerInstanceManagementClient,
+        container_group: ContainerGroup,
+        max_lines: int = 100,
+    ) -> str:
+        """
+        Gets the most container logs up to a given maximum.
+
+        Args:
+            client: An initialized `ContainerInstanceManagementClient`
+            container_group: The container group that holds the job container.
+            max_lines: The number of log lines to pull. Defaults to 100.
+
+        Returns:
+            A string containing the requested log entries, one per line.
+        """
+        container = self._get_container(container_group)
+
+        logs: Union[Logs, None] = None
+        try:
+            logs = client.containers.list_logs(
+                resource_group_name=self.resource_group_name,
+                container_group_name=container_group.name,
+                container_name=container.name,
+                tail=max_lines,
+                timestamps=True,
+            )
+        except HttpResponseError:
+            # Trying to get logs when the container is under heavy CPU load sometimes
+            # results in an error, but we won't want to raise an exception and stop
+            # monitoring the flow. Instead, log the error and carry on so we can try to
+            # get all missed logs on the next check.
+            self.logger.warning(
+                f"{self._log_prefix}: Unable to retrieve logs from container "
+                f"{container.name}. Trying again in {self.task_watch_poll_interval}s"
+            )
+
+        return logs.content if logs else ""
+
+    def _stream_output(
+        self, log_content: Union[str, None], last_log_time: datetime.datetime
+    ) -> datetime.datetime:
+        """
+        Writes each entry from a string of log lines to stderr.
+
+        Args:
+            log_content: A string containing Azure container logs.
+            last_log_time: The timestamp of the last output line already streamed.
+
+        Returns:
+            The time of the most recent output line written by this call.
+        """
+        if not log_content:
+            # nothing to stream
+            return last_log_time
+
+        log_lines = log_content.split("\n")
+
+        last_written_time = last_log_time
+
+        for log_line in log_lines:
+            # skip if the line is blank or whitespace
+            if not log_line.strip():
+                continue
+
+            line_parts = log_line.split(" ")
+            # timestamp should always be before first space in line
+            line_timestamp = line_parts[0]
+            line = " ".join(line_parts[1:])
+
+            try:
+                line_time = dateutil.parser.parse(line_timestamp)
+                if line_time > last_written_time:
+                    self._write_output_line(line)
+                    last_written_time = line_time
+            except dateutil.parser.ParserError as e:
+                self.logger.debug(
+                    (
+                        f"{self._log_prefix}: Unable to parse timestamp from Azure "
+                        "log line: %s"
+                    ),
+                    log_line,
+                    exc_info=e,
+                )
+
+        return last_written_time
+
+    def _get_environment(self):
+        """
+        Generates a dictionary of all environment variables to send to the
+        ACI container.
+        """
+        return {**self._base_environment(), **self.env}
+
+    @property
+    def _log_prefix(self) -> str:
+        """
+        Internal property for generating a prefix for logs where `name` may be null
+        """
+        if self.name is not None:
+            return f"AzureContainerInstanceJob {self.name!r}"
+        else:
+            return "AzureContainerInstanceJob"
+
+    @staticmethod
+    def _provisioning_succeeded(container_group: Union[ContainerGroup, None]) -> bool:
+        """
+        Determines whether ACI container group provisioning was successful.
+
+        Args:
+            container_group: a container group returned by the Azure SDK.
+
+        Returns:
+            True if provisioning was successful, False otherwise.
+        """
+        if not container_group:
+            return False
+
+        return (
+            container_group.provisioning_state
+            == ContainerGroupProvisioningState.SUCCEEDED
+            and len(container_group.containers) == 1
+        )
+
+    @staticmethod
+    def _write_output_line(line: str):
+        """
+        Writes a line of output to stderr.
+        """
+        print(line, file=sys.stderr)

--- a/prefect_azure/workers/container_instance.py
+++ b/prefect_azure/workers/container_instance.py
@@ -316,7 +316,6 @@ class AzureContainerJobConfiguration(BaseJobConfiguration):
         # breaking EXTRA_PIP_PACKAGES installation on container startup.
         if self.entrypoint:
             self.command = f"{self.entrypoint} {self.command}"
-        )
 
     def _get_json_environment(self):
         env = {**self._base_environment(), **self.env}

--- a/tests/test_aci_worker.py
+++ b/tests/test_aci_worker.py
@@ -1,6 +1,6 @@
 import uuid
 from typing import Dict, List, Tuple, Union
-from unittest.mock import AsyncMock, MagicMock, Mock
+from unittest.mock import MagicMock, Mock
 
 import dateutil.parser
 import pytest
@@ -19,6 +19,7 @@ from prefect.server.schemas.core import Flow
 from prefect.exceptions import InfrastructureNotAvailable, InfrastructureNotFound
 from prefect.infrastructure.docker import DockerRegistry
 from prefect.settings import get_current_settings
+from prefect.testing.utilities import AsyncMock
 from pydantic import SecretStr
 
 import prefect_azure.container_instance

--- a/tests/test_aci_worker.py
+++ b/tests/test_aci_worker.py
@@ -804,7 +804,7 @@ async def test_output_streaming(
 def test_block_accessible_in_module_toplevel():
     # will raise an exception and fail the test if `AzureContainerInstanceJob`
     # is not accessible directly from `prefect_azure`
-    from prefect_azure import AzureContainerInstanceJob  # noqa
+    from prefect_azure import AzureContainerWorker  # noqa
 
 
 def test_registry_credentials(container_instance_block, mock_aci_client, monkeypatch):

--- a/tests/test_aci_worker.py
+++ b/tests/test_aci_worker.py
@@ -1,0 +1,862 @@
+import uuid
+from typing import Dict, List, Tuple, Union
+from unittest.mock import MagicMock, Mock
+
+import dateutil.parser
+import pytest
+from anyio.abc import TaskStatus
+from azure.core.exceptions import HttpResponseError, ResourceNotFoundError
+from azure.identity import ClientSecretCredential
+from azure.mgmt.containerinstance.models import (
+    EnvironmentVariable,
+    ImageRegistryCredential,
+    UserAssignedIdentities,
+)
+from azure.mgmt.resource import ResourceManagementClient
+from prefect.client.schemas import FlowRun
+from prefect.exceptions import InfrastructureNotAvailable, InfrastructureNotFound
+from prefect.infrastructure.docker import DockerRegistry
+from prefect.settings import get_current_settings
+from pydantic import SecretStr
+
+import prefect_azure.container_instance
+from prefect_azure import AzureContainerInstanceCredentials
+from prefect_azure.workers.container_instance import (
+    AzureContainerJobConfiguration,
+    AzureContainerWorker,
+    AzureContainerWorkerResult,
+    ContainerGroupProvisioningState,
+    ContainerRunState,
+)
+
+# Helper functions
+
+
+def credential_values(
+    credentials: AzureContainerInstanceCredentials,
+) -> Tuple[str, str, str]:
+    """
+    Helper function to extract values from an Azure container instances
+    credential block
+
+    Args:
+        credential: The credential to extract values from
+
+    Returns:
+        A tuple containing (client_id, client_secret, tenant_id) from
+        the credentials block
+    """
+    return (
+        credentials.client_id,
+        credentials.client_secret.get_secret_value(),
+        credentials.tenant_id,
+    )
+
+
+def create_mock_container_group(state: str, exit_code: Union[int, None]):
+    """
+    Creates a mock container group with a single container to serve as a stand-in for
+    an Azure ContainerInstanceManagementClient's container_group property.
+
+    Args:
+        state: The state the single container in the group should report.
+        exit_code: The container's exit code, or None
+
+    Returns:
+        A mock container group.
+    """
+    container_group = Mock()
+    containers = MagicMock()
+    container = Mock()
+    container.instance_view.current_state.state = state
+    container.instance_view.current_state.exit_code = exit_code
+    containers.__getitem__.return_value = container
+    container_group.containers = containers
+    # Azure assigns all provisioned container groups a stringified
+    # UUID name.
+    container_group.name = str(uuid.uuid4())
+    return container_group
+
+
+# Fixtures
+@pytest.fixture
+def aci_credentials():
+    client_id = "test_client_id"
+    client_secret = "test_client_secret"
+    tenant_id = "test_tenant_id"
+
+    credentials = AzureContainerInstanceCredentials(
+        client_id=client_id, client_secret=client_secret, tenant_id=tenant_id
+    )
+    return credentials
+
+
+@pytest.fixture()
+def job_configuration(aci_credentials):
+    """
+    Returns a basic initialized ACI infrastructure block suitable for use
+    in a variety of tests.
+    """
+    container_instance_configuration = AzureContainerJobConfiguration(
+        command="test",
+        aci_credentials=aci_credentials,
+        resource_group_name="test_group",
+        subscription_id=SecretStr("sub_id"),
+        name=None,
+        task_watch_poll_interval=0.05,
+        task_start_timeout_seconds=0.10,  # noqa
+    )
+
+    return container_instance_configuration
+
+
+@pytest.fixture()
+def mock_aci_client(monkeypatch, mock_resource_client):
+    """
+    A fixture that provides a mock Azure Container Instances client
+    """
+    container_groups = Mock(name="container_group")
+    creation_status_poller = Mock(name="created container groups")
+    creation_status_poller_result = Mock(name="created container groups result")
+    container_groups.begin_create_or_update.side_effect = (
+        lambda *args: creation_status_poller
+    )
+    creation_status_poller.result.side_effect = lambda: creation_status_poller_result
+    creation_status_poller_result.provisioning_state = (
+        ContainerGroupProvisioningState.SUCCEEDED
+    )
+    creation_status_poller_result.name = str(uuid.uuid4())
+    container = Mock()
+    container.instance_view.current_state.exit_code = 0
+    container.instance_view.current_state.state = ContainerRunState.TERMINATED
+    containers = Mock(name="containers", containers=[container])
+    container_groups.get.side_effect = [containers]
+    creation_status_poller_result.containers = [containers]
+
+    aci_client = Mock(container_groups=container_groups)
+    monkeypatch.setattr(
+        prefect_azure.credentials,
+        "ContainerInstanceManagementClient",
+        Mock(return_value=aci_client),
+    )
+    return aci_client
+
+
+@pytest.fixture()
+def mock_successful_container_group():
+    """
+    A fixture that returns a mock container group that mimics a successfully
+    provisioned container group returned from Azure.
+    """
+
+    return create_mock_container_group(state="Terminated", exit_code=0)
+
+
+@pytest.fixture()
+def mock_running_container_group():
+    return create_mock_container_group(state="Running", exit_code=None)
+
+
+@pytest.fixture()
+def mock_resource_client(monkeypatch):
+    mock_resource_client = MagicMock(spec=ResourceManagementClient)
+
+    def return_group(name: str):
+        client = ResourceManagementClient
+        return client.models().ResourceGroup(name=name, location="useast")
+
+    mock_resource_client.resource_groups.get = Mock(side_effect=return_group)
+
+    monkeypatch.setattr(
+        AzureContainerInstanceCredentials,
+        "get_resource_client",
+        MagicMock(return_value=mock_resource_client),
+    )
+
+    return mock_resource_client
+
+
+# Tests
+
+
+def test_valid_command_validation(aci_credentials):
+    # ensure the validator allows valid commands to pass through
+    command = "command arg1 arg2"
+
+    aci_job_config = AzureContainerJobConfiguration(
+        command=command,
+        subscription_id=SecretStr("test"),
+        resource_group_name="test",
+        aci_credentials=aci_credentials,
+    )
+
+    assert aci_job_config.command == command
+
+
+def test_invalid_command_validation(aci_credentials):
+    # ensure invalid commands cause a validation error
+    with pytest.raises(ValueError):
+        AzureContainerJobConfiguration(
+            command=["invalid_command", "arg1", "arg2"],  # noqa
+            subscription_id=SecretStr("test"),
+            resource_group_name="test",
+            aci_credentials=aci_credentials,
+        )
+
+
+def test_container_client_creation(
+    aci_credentials, container_instance_block, monkeypatch
+):
+    # verify that the Azure Container Instances client and Azure Resource clients
+    # are created correctly.
+
+    mock_azure_credential = Mock(spec=ClientSecretCredential)
+    monkeypatch.setattr(
+        prefect_azure.credentials,
+        "ClientSecretCredential",
+        Mock(return_value=mock_azure_credential),
+    )
+
+    # don't use the mock_aci_client or mock_resource_client_fixtures, because we want to
+    # test the call to the client constructors to ensure the block is calling them
+    # with the correct information.
+    mock_container_client_constructor = Mock()
+    monkeypatch.setattr(
+        prefect_azure.credentials,
+        "ContainerInstanceManagementClient",
+        mock_container_client_constructor,
+    )
+
+    mock_resource_client_constructor = Mock()
+    monkeypatch.setattr(
+        prefect_azure.credentials,
+        "ResourceManagementClient",
+        mock_resource_client_constructor,
+    )
+
+    subscription_id = "test_subscription"
+    container_instance_block.subscription_id = SecretStr(value=subscription_id)
+    with pytest.raises(RuntimeError):
+        container_instance_block.run()
+
+    mock_resource_client_constructor.assert_called_once_with(
+        credential=mock_azure_credential,
+        subscription_id=subscription_id,
+    )
+    mock_container_client_constructor.assert_called_once_with(
+        credential=mock_azure_credential,
+        subscription_id=subscription_id,
+    )
+
+
+@pytest.mark.usefixtures("mock_aci_client")
+def test_credentials_are_used(container_instance_block, mock_aci_client, monkeypatch):
+    credentials = container_instance_block.aci_credentials
+    (client_id, client_secret, tenant_id) = credential_values(credentials)
+
+    mock_client_secret = Mock(name="Mock client secret", return_value=client_secret)
+    mock_credential = Mock(wraps=ClientSecretCredential)
+
+    monkeypatch.setattr(
+        credentials.client_secret, "get_secret_value", mock_client_secret
+    )
+    monkeypatch.setattr(
+        prefect_azure.credentials, "ClientSecretCredential", mock_credential
+    )
+
+    container_instance_block.run()
+
+    mock_client_secret.assert_called_once()
+    mock_credential.assert_called_once_with(
+        client_id=client_id, client_secret=client_secret, tenant_id=tenant_id
+    )
+
+
+def test_container_creation_call(mock_aci_client, container_instance_block):
+    # ensure the block always tries to call the Azure SDK to create the container
+    container_instance_block.run()
+    mock_aci_client.container_groups.begin_create_or_update.assert_called_once()
+
+
+def test_entrypoint_used_if_provided(
+    container_instance_block, mock_aci_client, monkeypatch
+):
+    mock_container = Mock()
+    mock_container.name = "TestContainer"
+    mock_container_constructor = Mock(return_value=mock_container)
+    monkeypatch.setattr(
+        prefect_azure.container_instance, "Container", mock_container_constructor
+    )
+
+    entrypoint = "/test/entrypoint.sh"
+    container_instance_block.entrypoint = entrypoint
+    container_instance_block.run()
+
+    mock_container_constructor.assert_called_once()
+    (_, kwargs) = mock_container_constructor.call_args
+    assert kwargs.get("command")[0] == entrypoint
+
+
+def test_runs_without_entrypoint(
+    container_instance_block, mock_aci_client, monkeypatch
+):
+    mock_container = Mock()
+    mock_container.name = "TestContainer"
+    mock_container_constructor = Mock(return_value=mock_container)
+    monkeypatch.setattr(
+        prefect_azure.container_instance, "Container", mock_container_constructor
+    )
+
+    default_command = container_instance_block.command
+    container_instance_block.entrypoint = None
+    container_instance_block.run()
+
+    mock_container_constructor.assert_called_once()
+    (_, kwargs) = mock_container_constructor.call_args
+    assert kwargs.get("command")[0] == " ".join(default_command)
+
+
+def test_delete_after_group_creation_failure(
+    job_configuration, mock_aci_client, monkeypatch
+):
+    # if provisioning failed, the container group should be deleted
+    mock_container_group = Mock()
+    mock_container_group.provisioning_state.return_value = (
+        ContainerGroupProvisioningState.FAILED
+    )
+    container_worker = AzureContainerWorker()
+
+    monkeypatch.setattr(
+        container_worker, "_wait_for_task_container_start", mock_container_group
+    )
+    with pytest.raises(RuntimeError, match="Container creation failed"):
+        container_worker.run(FlowRun(name="Test"), configuration=job_configuration)
+    mock_aci_client.container_groups.begin_delete.assert_called_once()
+
+
+def test_no_delete_if_no_container_group(
+    container_instance_block, mock_aci_client, monkeypatch
+):
+    # if provisioning failed because the ACI client returned nothing,
+    # we should not attempt to delete the container group because we don't
+    # have enough data to try
+    monkeypatch.setattr(
+        container_instance_block,
+        "_wait_for_task_container_start",
+        Mock(return_value=None),
+    )
+    with pytest.raises(RuntimeError, match="Container creation failed"):
+        container_instance_block.run()
+    mock_aci_client.container_groups.begin_delete.assert_not_called()
+
+
+def test_delete_after_group_creation_success(
+    container_instance_block, mock_aci_client, monkeypatch
+):
+    # if provisioning was successful, the container group should eventually be deleted
+    container_instance_block.run()
+    mock_aci_client.container_groups.begin_delete.assert_called_once()
+
+
+def test_delete_after_after_exception(
+    container_instance_block, mock_aci_client, monkeypatch
+):
+    # if an exception was thrown while waiting for container group provisioning,
+    # the group should be deleted
+    mock_aci_client.container_groups.begin_create_or_update.side_effect = (
+        HttpResponseError(message="it broke")
+    )
+
+    with pytest.raises(HttpResponseError):
+        container_instance_block.run()
+
+    mock_aci_client.container_groups.begin_create_or_update.assert_called_once()
+
+
+@pytest.mark.usefixtures("mock_aci_client")
+def test_task_status_started_on_provisioning_success(
+    container_instance_block, mock_successful_container_group, monkeypatch
+):
+    monkeypatch.setattr(
+        container_instance_block, "_provisioning_succeeded", Mock(return_value=True)
+    )
+
+    monkeypatch.setattr(
+        container_instance_block,
+        "_wait_for_task_container_start",
+        Mock(return_value=mock_successful_container_group),
+    )
+
+    task_status = Mock(spec=TaskStatus)
+    container_instance_block.run(task_status=task_status)
+
+    task_status.started.assert_called_once_with(
+        value=mock_successful_container_group.name
+    )
+
+
+@pytest.mark.usefixtures("mock_aci_client")
+def test_task_status_not_started_on_provisioning_failure(
+    container_instance_block, mock_successful_container_group, monkeypatch
+):
+    monkeypatch.setattr(
+        container_instance_block, "_provisioning_succeeded", Mock(return_value=False)
+    )
+
+    task_status = Mock(spec=TaskStatus)
+    with pytest.raises(RuntimeError, match="Container creation failed"):
+        container_instance_block.run(task_status=task_status)
+    task_status.started.assert_not_called()
+
+
+def test_provisioning_timeout_throws_exception(
+    mock_aci_client, container_instance_block
+):
+    mock_poller = Mock()
+    mock_poller.done.return_value = False
+    mock_aci_client.container_groups.begin_create_or_update.side_effect = (
+        lambda *args: mock_poller
+    )
+
+    # avoid delaying test runs
+    container_instance_block.task_watch_poll_interval = 0.09
+    container_instance_block.task_start_timeout_seconds = 0.10
+
+    with pytest.raises(RuntimeError, match="Timed out after"):
+        container_instance_block.run()
+
+
+def test_watch_for_container_termination(
+    mock_aci_client,
+    mock_running_container_group,
+    mock_successful_container_group,
+    container_instance_block,
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        container_instance_block, "_provisioning_succeeded", Mock(return_value=True)
+    )
+
+    monkeypatch.setattr(
+        container_instance_block,
+        "_wait_for_task_container_start",
+        Mock(return_value=mock_running_container_group),
+    )
+
+    # make the block wait a few times before we give it a successful result
+    # so we can make sure the watcher actually watches instead of skipping
+    # the timeout
+    run_count = 0
+
+    def get_container_group(**kwargs):
+        nonlocal run_count
+        run_count += 1
+        if run_count < 5:
+            return mock_running_container_group
+        else:
+            return mock_successful_container_group
+
+    mock_aci_client.container_groups.get.side_effect = get_container_group
+
+    container_instance_block.task_watch_poll_interval = 0.02
+    result = container_instance_block.run()
+
+    # ensure the watcher was watching
+    assert run_count == 5
+    assert mock_aci_client.container_groups.get.call_count == run_count
+    # ensure the run completed
+    assert isinstance(result, AzureContainerWorkerResult)
+
+
+def test_watch_for_quick_termination(
+    mock_aci_client,
+    mock_successful_container_group,
+    container_instance_block,
+    monkeypatch,
+):
+    # ensure that everything works as expected in the case where the container has
+    # already finished its flow run by the time the poller picked up the container
+    # group's successful provisioning status.
+
+    monkeypatch.setattr(
+        container_instance_block, "_provisioning_succeeded", Mock(return_value=True)
+    )
+
+    monkeypatch.setattr(
+        container_instance_block,
+        "_wait_for_task_container_start",
+        Mock(return_value=mock_successful_container_group),
+    )
+
+    result = container_instance_block.run()
+
+    # ensure the watcher didn't need to call to check status since the run
+    # already completed.
+    mock_aci_client.container_groups.get.assert_not_called()
+    # ensure the run completed
+    assert isinstance(result, AzureContainerWorkerResult)
+
+
+@pytest.mark.usefixtures("mock_aci_client")
+def test_subnets_included_when_present(container_instance_block, monkeypatch):
+    mock_container_group_cls = MagicMock()
+
+    monkeypatch.setattr(
+        prefect_azure.container_instance, "ContainerGroup", mock_container_group_cls
+    )
+    subnet_ids = ["subnet1", "subnet2", "subnet3"]
+    container_instance_block.subnet_ids = subnet_ids
+    container_instance_block.run()
+    mock_container_group_cls.assert_called_once()
+
+    (_, kwargs) = mock_container_group_cls.call_args
+    subnet_args = kwargs.get("subnet_ids")
+    assert len(subnet_args) == len(subnet_ids)
+    for subnet_id in subnet_ids:
+        assert subnet_id in subnet_ids
+
+
+def test_preview(aci_credentials):
+    # ensures the preview generates the JSON expected
+    block_args = {
+        "resource_group_name": "test-group",
+        "memory": 1.0,
+        "cpu": 1.0,
+        "gpu_count": 1,
+        "gpu_sku": "V100",
+        "env": {"FAVORITE_ANIMAL": "cat"},
+    }
+
+    raise NotImplementedError("This test needs to be updated to use the new ACI worker")
+    # block = AzureContainerInstanceJob(
+    #     **block_args, aci_credentials=aci_credentials, subscription_id=SecretStr("test")
+    # )
+    #
+    # preview = json.loads(block.preview())
+    #
+    # for (k, v) in block_args.items():
+    #     if k == "env":
+    #         for (k2, v2) in block_args["env"].items():
+    #             assert preview[k][k2] == block_args["env"][k2]
+    #
+    #     else:
+    #         assert preview[k] == block_args[k]
+
+
+def test_output_streaming(
+    container_instance_block,
+    mock_aci_client,
+    mock_running_container_group,
+    mock_successful_container_group,
+    monkeypatch,
+):
+    # override datetime.now to ensure run start time is before log line timestamps
+    run_start_time = dateutil.parser.parse("2022-10-03T20:40:05.3119525Z")
+    mock_datetime = Mock()
+    mock_datetime.datetime.now.return_value = run_start_time
+
+    monkeypatch.setattr(prefect_azure.container_instance, "datetime", mock_datetime)
+
+    log_lines = """
+2022-10-03T20:41:05.3119525Z 20:41:05.307 | INFO    | Flow run 'ultramarine-dugong' - Created task run "Test-39fdf8ff-0" for task "ACI Test"
+2022-10-03T20:41:05.3120697Z 20:41:05.308 | INFO    | Flow run 'ultramarine-dugong' - Executing "Test-39fdf8ff-0" immediately...
+2022-10-03T20:41:05.6215928Z 20:41:05.616 | INFO    | Task run "Test-39fdf8ff-0" - Test Message
+2022-10-03T20:41:05.7758864Z 20:41:05.775 | INFO    | Task run "Test-39fdf8ff-0" - Finished in state Completed()
+"""  # noqa
+
+    # include some overlap in the second batch so we can make sure output
+    # is not duplicated
+    next_log_lines = """
+2022-10-03T20:41:05.6215928Z 20:41:05.616 | INFO    | Task run "Test-39fdf8ff-0" - Test Message
+2022-10-03T20:41:05.7758864Z 20:41:05.775 | INFO    | Task run "Test-39fdf8ff-0" - Finished in state Completed()
+2022-10-03T20:41:13.0149593Z 20:41:13.012 | INFO    | Flow run 'ultramarine-dugong' - Created task run "Test-39fdf8ff-1" for task "ACI Test"
+2022-10-03T20:41:13.0152433Z 20:41:13.013 | INFO    | Flow run 'ultramarine-dugong' - Executing "Test-39fdf8ff-1" immediately...
+2022-broken-03T20:41:13.0152433Z 20:41:13.013 | INFO    | Log line with broken timestamp should not be printed
+    """  # noqa
+
+    log_count = 0
+
+    def get_logs(*args, **kwargs):
+        nonlocal log_count
+        logs = Mock()
+        if log_count == 0:
+            log_count += 1
+            logs.content = log_lines
+        elif log_count == 1:
+            log_count += 1
+            logs.content = next_log_lines
+        else:
+            logs.content = ""
+
+        return logs
+
+    run_count = 0
+
+    def get_container_group(**kwargs):
+        nonlocal run_count
+        run_count += 1
+        if run_count < 4:
+            return mock_running_container_group
+        else:
+            return mock_successful_container_group
+
+    mock_aci_client.container_groups.get.side_effect = get_container_group
+
+    mock_log_call = Mock(side_effect=get_logs)
+    monkeypatch.setattr(mock_aci_client.containers, "list_logs", mock_log_call)
+
+    mock_write_call = Mock(wraps=container_instance_block._write_output_line)
+    monkeypatch.setattr(container_instance_block, "_write_output_line", mock_write_call)
+
+    monkeypatch.setattr(
+        container_instance_block, "_provisioning_succeeded", Mock(return_value=True)
+    )
+
+    monkeypatch.setattr(
+        container_instance_block,
+        "_wait_for_task_container_start",
+        Mock(return_value=mock_running_container_group),
+    )
+
+    container_instance_block.stream_output = True
+    container_instance_block.name = "streaming test"
+    container_instance_block.task_watch_poll_interval = 0.02
+    container_instance_block.run()
+
+    # 6 lines should be written because of the nine test log lines, two overlap
+    # and should not be written twice, and one has a broken timestamp so should
+    # not be written
+    assert mock_write_call.call_count == 6
+
+
+def test_block_accessible_in_module_toplevel():
+    # will raise an exception and fail the test if `AzureContainerInstanceJob`
+    # is not accessible directly from `prefect_azure`
+    from prefect_azure import AzureContainerInstanceJob  # noqa
+
+
+def test_registry_credentials(container_instance_block, mock_aci_client, monkeypatch):
+    mock_container_group_constructor = MagicMock()
+
+    monkeypatch.setattr(
+        prefect_azure.container_instance,
+        "ContainerGroup",
+        mock_container_group_constructor,
+    )
+
+    registry = DockerRegistry(
+        username="username",
+        password="password",
+        registry_url="https://myregistry.dockerhub.com",
+    )
+
+    container_instance_block.image_registry = registry
+    container_instance_block.run()
+
+    mock_container_group_constructor.assert_called_once()
+
+    (_, kwargs) = mock_container_group_constructor.call_args
+    registry_arg: List[ImageRegistryCredential] = kwargs.get(
+        "image_registry_credentials"
+    )
+
+    # ensure the registry was used, passed as a list the way the Azure SDK expects it,
+    # and correctly converted to an Azure ImageRegistryCredential.
+    assert registry_arg is not None
+    assert isinstance(registry_arg, list)
+
+    registry_object = registry_arg[0]
+    assert isinstance(registry_object, ImageRegistryCredential)
+    assert registry_object.username == registry.username
+    assert registry_object.password == registry.password.get_secret_value()
+    assert registry_object.server == registry.registry_url
+
+
+def test_secure_environment_variables(
+    container_instance_block, mock_aci_client, monkeypatch
+):
+    # setup environment containing an API key we want to keep secret
+    base_env: Dict[str, str] = get_current_settings().to_environment_variables(
+        exclude_unset=True
+    )
+    base_env["PREFECT_API_KEY"] = "my-api-key"
+
+    base_env_call = Mock(return_value=base_env)
+    monkeypatch.setattr(container_instance_block, "_base_environment", base_env_call)
+
+    mock_container_constructor = Mock()
+    monkeypatch.setattr(
+        prefect_azure.container_instance, "Container", mock_container_constructor
+    )
+
+    container_instance_block.run()
+
+    mock_container_constructor.assert_called_once()
+    (_, kwargs) = mock_container_constructor.call_args
+    env_variables_parameter: List = kwargs.get("environment_variables")
+
+    api_key_aci_env_variable: List[EnvironmentVariable] = list(
+        filter(lambda v: v.name == "PREFECT_API_KEY", env_variables_parameter)
+    )
+
+    # ensure the env variable made it into the list of env variables set in the
+    # ACI container
+    assert len(api_key_aci_env_variable) == 1
+    assert api_key_aci_env_variable[0].name == "PREFECT_API_KEY"
+    # ensure that `secure_value` was used instead of `value`
+    assert api_key_aci_env_variable[0].value is None
+    assert api_key_aci_env_variable[0].secure_value == "my-api-key"
+
+
+async def test_kill_deletes_container_group(
+    container_instance_block, mock_aci_client, mock_running_container_group, monkeypatch
+):
+    container_group_name = "test_container_group"
+    mock_running_container_group.name = container_group_name
+
+    # simulate a running container to avoid `InfrastructureNotAvailable` exception
+    # since it is covered in a separate test
+    container = Mock(name="container")
+    container.instance_view.current_state.state = ContainerRunState.RUNNING
+
+    mock_aci_client.container_groups.get.side_effect = Mock(
+        name="container_group", return_value=mock_running_container_group
+    )
+
+    # shorten wait time
+    monkeypatch.setattr(
+        prefect_azure.container_instance,
+        "CONTAINER_GROUP_DELETION_TIMEOUT_SECONDS",
+        0.1,
+    )
+    container_instance_block.task_watch_poll_interval = 0.02
+
+    await container_instance_block.kill(container_group_name)
+
+    mock_aci_client.container_groups.begin_delete.assert_called_once_with(
+        resource_group_name=container_instance_block.resource_group_name,
+        container_group_name=container_group_name,
+    )
+
+
+async def test_kill_raises_not_found_when_container_group_gone(
+    container_instance_block, mock_aci_client
+):
+    mock_aci_client.container_groups.get.side_effect = ResourceNotFoundError()
+
+    # ResourceNotFoundError means the container group no longers exists on Azure, so
+    # it should always cause an InfrastructureNotFound exception
+    with pytest.raises(InfrastructureNotFound):
+        await container_instance_block.kill("test_container_group")
+
+
+async def test_kill_raises_not_available_when_container_terminated(
+    container_instance_block, mock_aci_client
+):
+    # mock_aci_client already contains a mock container group that has finished running,
+    # i.e. its status is ContainerRunState.TERMINATED, so it should trigger
+    # InfrastructureNotAvailable as-is
+
+    with pytest.raises(InfrastructureNotAvailable):
+        await container_instance_block.kill("test_container_group")
+
+
+async def test_run_exits_when_resource_group_disappears(
+    container_instance_block, mock_aci_client, mock_running_container_group
+):
+    """
+    Test to ensure that when a flow run is cancelled, the container group will disappear
+    mid-run. Ensure the run method exits gracefully instead of showing an exception
+    since the user requested cancellation.
+    """
+
+    # make the block wait a few times before the container group disappears
+    # to simulate what happens when a flow is cancelled before it completes.
+    run_count = 0
+
+    def get_container_group(**kwargs):
+        nonlocal run_count
+        run_count += 1
+        if run_count < 3:
+            return mock_running_container_group
+        else:
+            raise ResourceNotFoundError()
+
+    mock_aci_client.container_groups.get.side_effect = get_container_group
+
+    container_instance_block.task_watch_poll_interval = 0.02
+
+    status_code = await container_instance_block.run()
+
+    # Expect a non-success status code. This ensures that the flow status is set to
+    # CRASHED if the container group's absence was not caused by cancellation.
+    assert status_code != 0
+
+
+async def test_identities_used_if_provided(
+    container_instance_block, mock_aci_client, monkeypatch
+):
+    mock_container_group = Mock(name="TestContainerGroup")
+    mock_container_group_constructor = Mock(return_value=mock_container_group)
+    monkeypatch.setattr(
+        prefect_azure.container_instance,
+        "ContainerGroup",
+        mock_container_group_constructor,
+    )
+
+    mock_container_group_identity = Mock()
+    mock_identities_constructor = Mock(return_value=mock_container_group_identity)
+    monkeypatch.setattr(
+        prefect_azure.container_instance,
+        "ContainerGroupIdentity",
+        mock_identities_constructor,
+    )
+
+    identities = [
+        "/my/managed_identity/one",
+        "/my/managed_identity/two",
+    ]
+
+    container_instance_block.identities = identities
+    await container_instance_block.run()
+
+    expected_identities_param = {
+        identity: UserAssignedIdentities() for identity in identities
+    }
+    mock_identities_constructor.assert_called_once_with(
+        type="UserAssigned", user_assigned_identities=expected_identities_param
+    )
+
+    mock_container_group_constructor.assert_called_once()
+    (_, kwargs) = mock_container_group_constructor.call_args
+    assert kwargs.get("identity") == mock_container_group_identity
+
+
+async def test_dns_config_used_if_provided(
+    container_instance_block, mock_aci_client, monkeypatch
+):
+    mock_container_group = Mock(name="TestContainerGroup")
+    mock_container_group_constructor = Mock(return_value=mock_container_group)
+    monkeypatch.setattr(
+        prefect_azure.container_instance,
+        "ContainerGroup",
+        mock_container_group_constructor,
+    )
+
+    mock_dns_config = Mock()
+    mock_dns_config_constructor = Mock(return_value=mock_dns_config)
+    monkeypatch.setattr(
+        prefect_azure.container_instance,
+        "DnsConfiguration",
+        mock_dns_config_constructor,
+    )
+
+    dns_servers = ["1.2.3.4", "5.6.7.8", "9.10.11.12"]
+    container_instance_block.dns_servers = dns_servers
+    await container_instance_block.run()
+
+    mock_dns_config_constructor.assert_called_once_with(name_servers=dns_servers)
+
+    mock_container_group_constructor.assert_called_once()
+    (_, kwargs) = mock_container_group_constructor.call_args
+    assert kwargs.get("dns_config") == mock_dns_config


### PR DESCRIPTION
This WIP PR adds a Prefect worker for Azure Container Instances. 

See [the Prefect docs](https://docs.prefect.io/latest/concepts/work-pools/#worker-overview) for full details on workers.

This worker aims to handle every use case the Azure Container Instances block covers, while adding flexibility by providing a user-cuztomizable Azure Resource Manager deployment template.


### Example
<!-- A code blurb is best. Changes to features should include an example that is executable by a new user. -->

### Screenshots
<!--
Any relevant screenshots
  - The updated docs page from `mkdocs serve`.
  - Output from running the example.
  - Service integration test results.
-->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] References any related issue by including "Closes #<Issue Number>" or "Closes <Issue URL>".
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect-azure/issues/new/choose) first.
- [ ] Includes tests or only affects documentation.
- [ ] Passes `pre-commit` checks.
  - Run `pre-commit install && pre-commit run --all` locally for formatting and linting.
- [ ] Includes screenshots of documentation updates.
  - Run `mkdocs serve` view documentation locally.
- [ ] Summarizes PR's changes in [CHANGELOG.md](https://github.com/PrefectHQ/prefect-azure/blob/main/CHANGELOG.md)
