### PR TITLE
Add handling to set ARM template image with default when not provided by user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-Updated template for Azure Container Instance Worker - [#89](https://github.com/PrefectHQ/prefect-azure/pull/89)
+- Updated template for Azure Container Instance Worker - [#89](https://github.com/PrefectHQ/prefect-azure/pull/89)
+- Added handling to set ARM template image with default when not provided by user - [#93](https://github.com/PrefectHQ/prefect-azure/pull/93)
 
 ### Security
 


### PR DESCRIPTION
<!-- Thanks for contributing 🎉! Please ensure the title neatly summarizes the proposed changes. -->

<!-- Overview -->

Current implementation requires the user to define an image either in the work pool configuration or in a deployment's `infra_overrides`. This PR enhances the `AzureContainerWorker`'s `prepare_For_flow_run` method to populate the image in the ARM template prior to executing a flow run. This will ensure that if a user did not provide an image name, the default image name will be populated in the ARM template.

This PR also updates the API version used by the default ARM template, and adds some reasonable defaults to the `AzureContainerJobConfiguration` and `AzureContainerVariables` classes.

Closes #91 

### Example
<!-- A code blurb is best. Changes to features should include an example that is executable by a new user. -->

### Screenshots
<!--
Any relevant screenshots
  - The updated docs page from `mkdocs serve`.
  - Output from running the example.
  - Service integration test results.
-->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] References any related issue by including "Closes #<Issue Number>" or "Closes <Issue URL>".
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect-azure/issues/new/choose) first.
- [x] Includes tests or only affects documentation.
- [x] Passes `pre-commit` checks.
  - Run `pre-commit install && pre-commit run --all` locally for formatting and linting.
- [ ] Includes screenshots of documentation updates.
  - Run `mkdocs serve` view documentation locally.
- [x] Summarizes PR's changes in [CHANGELOG.md](https://github.com/PrefectHQ/prefect-azure/blob/main/CHANGELOG.md)
