### PR TITLE
Add `push` and `pull` steps for Azure Blob Storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,14 +17,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fixes bug where default Azure credentials could not be used - [#97](https://github.com/PrefectHQ/prefect-azure/pull/97)
-- Add py.typed marker to make the package PEP 561 compatible -[#100 ](https://github.com/PrefectHQ/prefect-azure/pull/100)
-
 ### Security
 
 ## 0.2.8
 
-Released on May 2nd, 2023.
+Released on June 15th, 2023.
 
 ### Added
 
@@ -33,6 +30,12 @@ Released on May 2nd, 2023.
 ### Changed
 
 - Added option to give containers created by `AzureContainerInstanceJob` human-readable names with a randomized suffix via the `name` attribute - [#92](https://github.com/PrefectHQ/prefect-azure/pull/92)
+
+### Fixed
+
+- Fixes bug where default Azure credentials could not be used - [#97](https://github.com/PrefectHQ/prefect-azure/pull/97)
+- Add py.typed marker to make the package PEP 561 compatible -[#100 ](https://github.com/PrefectHQ/prefect-azure/pull/100)
+
 
 ## 0.2.7
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+## 0.2.8
+
+Released on May 2nd, 2023.
+
+### Added
+
+- Added push and pull steps for Azure Blob Storage - [#95](https://github.com/PrefectHQ/prefect-azure/pull/95)
+
 ## 0.2.7
 
 Released on April 25th, 2023.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-Made created containers have human-readable names with a randomized suffix.
-
 ### Changed
 
 ### Deprecated
@@ -28,6 +26,10 @@ Released on May 2nd, 2023.
 ### Added
 
 - Added push and pull steps for Azure Blob Storage - [#95](https://github.com/PrefectHQ/prefect-azure/pull/95)
+
+### Changed
+
+- Added option to give containers created by `AzureContainerInstanceJob` human-readable names with a randomized suffix via the `name` attribute - [#92](https://github.com/PrefectHQ/prefect-azure/pull/92)
 
 ## 0.2.7
 

--- a/docs/deployments/steps.md
+++ b/docs/deployments/steps.md
@@ -1,0 +1,1 @@
+::: prefect_azure.deployments.steps

--- a/docs/projects/steps.md
+++ b/docs/projects/steps.md
@@ -1,0 +1,1 @@
+::: prefect_azure.projects.steps

--- a/docs/projects/steps.md
+++ b/docs/projects/steps.md
@@ -1,1 +1,0 @@
-::: prefect_azure.projects.steps

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -68,6 +68,8 @@ nav:
     - ML Datastore: ml_datastore.md
     - Container Instance Block: container_instance.md
     - Container Instance Worker: container_instance_worker.md
+    - Projects:
+      - Steps: projects/steps.md
 
 extra:
     social:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -68,8 +68,8 @@ nav:
     - ML Datastore: ml_datastore.md
     - Container Instance Block: container_instance.md
     - Container Instance Worker: container_instance_worker.md
-    - Projects:
-      - Steps: projects/steps.md
+    - Deployments:
+      - Steps: deployments/steps.md
 
 extra:
     social:

--- a/prefect_azure/credentials.py
+++ b/prefect_azure/credentials.py
@@ -72,18 +72,23 @@ def _raise_help_msg(key: str):
 
 class AzureBlobStorageCredentials(Block):
     """
-    Block used to manage Blob Storage authentication with Azure.
-    Azure authentication is handled via the `azure` module through
-    a connection string.
+    Stores credentials for authenticating with Azure Blob Storage.
 
     Args:
-        connection_string: Includes the authorization information required.
+        account_url: The URL for your Azure storage account. If provided, the account
+            URL will be used to authenticate with the discovered default Azure
+            credentials.
+        connection_string: The connection string to your Azure storage account. If
+            provided, the connection string will take precedence over the account URL.
 
     Example:
-        Load stored Azure Blob Storage credentials:
+        Load stored Azure Blob Storage credentials and retrieve a blob service client:
         ```python
         from prefect_azure import AzureBlobStorageCredentials
+
         azure_credentials_block = AzureBlobStorageCredentials.load("BLOCK_NAME")
+
+        blob_service_client = azure_credentials_block.get_blob_client()
         ```
     """
 
@@ -94,15 +99,17 @@ class AzureBlobStorageCredentials(Block):
     connection_string: Optional[SecretStr] = Field(
         default=None,
         description=(
-            "If account_url is not provided, " "the connection string to authenticate."
+            "The connection string to your Azure storage account. If provided, the "
+            "connection string will take precedence over the account URL."
         ),
     )
     account_url: Optional[str] = Field(
         default=None,
+        title="Account URL",
         description=(
-            "If a connection string is not provided, "
-            "the URL to the Blob Storage account; will use "
-            "DefaultAzureCredential to authenticate."
+            "The URL for your Azure storage account. If provided, the account "
+            "URL will be used to authenticate with the discovered default "
+            "Azure credentials."
         ),
     )
 

--- a/prefect_azure/deployments/steps.py
+++ b/prefect_azure/deployments/steps.py
@@ -1,34 +1,34 @@
 """
-Prefect project steps for code storage and retrieval in Azure Blob Storage.
+Prefect deployment steps for code storage and retrieval in Azure Blob Storage.
 
-These steps can be used in a project's `prefect.yaml` file to define the default 
-push and pull steps for the entire project, or they can be used in a project's 
-`deployment.yaml` file to define the push and pull steps for a specific deployment.
+These steps can be used in a `prefect.yaml` file to define the default 
+push and pull steps for a group of deployments, or they can be used to 
+define the push and pull steps for a specific deployment.
 
 !!! example
-    Sample `prefect.yaml` file that is configured to push and pull a
-    project to and from an Azure Blob Storage container:
+    Sample `prefect.yaml` file that is configured to push and pull to and 
+    from an Azure Blob Storage container:
 
     ```yaml
     prefect_version: ...
     name: ...
 
     push:
-        - prefect_azure.projects.steps.push_project_to_azure_blob_storage:
+        - prefect_azure.deployments.steps.push_to_azure_blob_storage:
             requires: prefect-azure[blob_storage]
             container: my-container
             folder: my-project
             credentials: "{{ prefect.blocks.azure-blob-storage-credentials.dev-credentials }}"
 
     pull:
-        - prefect_azure.projects.steps.pull_project_from_azure_blob_storage:
+        - prefect_azure.deployments.steps.pull_from_azure_blob_storage:
             requires: prefect-azure[blob_storage]
             container: "{{ container }}"
             folder: "{{ folder }}"
             credentials: "{{ prefect.blocks.azure-blob-storage-credentials.dev-credentials }}"
     ```
 
-For more information about using project steps, check out out the Prefect [docs](https://docs.prefect.io/latest/concepts/projects/#the-prefect-yaml-file).
+For more information about using deployment steps, check out out the Prefect [docs](https://docs.prefect.io/latest/concepts/projects/#the-prefect-yaml-file).
 """  # noqa
 from pathlib import Path, PurePosixPath
 from typing import Dict, Optional
@@ -38,17 +38,17 @@ from azure.storage.blob import ContainerClient
 from prefect.utilities.filesystem import filter_files, relative_path_to_current_platform
 
 
-def push_project_to_azure_blob_storage(
+def push_to_azure_blob_storage(
     container: str,
     folder: str,
     credentials: Dict[str, str],
     ignore_file: Optional[str] = ".prefectignore",
 ):
     """
-    Pushes a project to an Azure Blob Storage container.
+    Pushes to an Azure Blob Storage container.
 
     Args:
-        container: The name of the container to push project files to
+        container: The name of the container to push files to
         folder: The folder within the container to push to
         credentials: A dictionary of credentials with keys `connection_string` or
             `account_url` and values of the corresponding connection string or
@@ -58,22 +58,22 @@ def push_project_to_azure_blob_storage(
             file will be used.
 
     Example:
-        Push a project to an Azure Blob Storage container using credentials stored in a
+        Push to an Azure Blob Storage container using credentials stored in a
         block:
         ```yaml
         push:
-            - prefect_azure.projects.steps.push_project_to_azure_blob_storage:
+            - prefect_azure.deployments.steps.push_to_azure_blob_storage:
                 requires: prefect-azure[blob_storage]
                 container: my-container
                 folder: my-project
                 credentials: "{{ prefect.blocks.azure-blob-storage-credentials.dev-credentials }}"
         ```
 
-        Push a project to an Azure Blob Storage container using an account URL and
+        Push to an Azure Blob Storage container using an account URL and
         default credentials:
         ```yaml
         push:
-            - prefect_azure.projects.steps.push_project_to_azure_blob_storage:
+            - prefect_azure.deployments.steps.push_to_azure_blob_storage:
                 requires: prefect-azure[blob_storage]
                 container: my-container
                 folder: my-project
@@ -124,38 +124,38 @@ def push_project_to_azure_blob_storage(
     }
 
 
-def pull_project_from_azure_blob_storage(
+def pull_from_azure_blob_storage(
     container: str,
     folder: str,
     credentials: Dict[str, str],
 ):
     """
-    Pulls a project from an Azure Blob Storage container.
+    Pulls from an Azure Blob Storage container.
 
     Args:
-        container: The name of the container to pull project files from
+        container: The name of the container to pull files from
         folder: The folder within the container to pull from
         credentials: A dictionary of credentials with keys `connection_string` or
             `account_url` and values of the corresponding connection string or
             account url. If both are provided, `connection_string` will be used.
 
     Example:
-        Pull a project from an Azure Blob Storage container using credentials stored in
+        Pull from an Azure Blob Storage container using credentials stored in
         a block:
         ```yaml
         pull:
-            - prefect_azure.projects.steps.pull_project_from_azure_blob_storage:
+            - prefect_azure.deployments.steps.pull_from_azure_blob_storage:
                 requires: prefect-azure[blob_storage]
                 container: my-container
                 folder: my-project
                 credentials: "{{ prefect.blocks.azure-blob-storage-credentials.dev-credentials }}"
         ```
 
-        Pull a project from an Azure Blob Storage container using an account URL and
+        Pull from an Azure Blob Storage container using an account URL and
         default credentials:
         ```yaml
         pull:
-            - prefect_azure.projects.steps.pull_project_from_azure_blob_storage:
+            - prefect_azure.deployments.steps.pull_from_azure_blob_storage:
                 requires: prefect-azure[blob_storage]
                 container: my-container
                 folder: my-project

--- a/prefect_azure/deployments/steps.py
+++ b/prefect_azure/deployments/steps.py
@@ -17,7 +17,7 @@ define the push and pull steps for a specific deployment.
         - prefect_azure.deployments.steps.push_to_azure_blob_storage:
             requires: prefect-azure[blob_storage]
             container: my-container
-            folder: my-project
+            folder: my-folder
             credentials: "{{ prefect.blocks.azure-blob-storage-credentials.dev-credentials }}"
 
     pull:
@@ -65,7 +65,7 @@ def push_to_azure_blob_storage(
             - prefect_azure.deployments.steps.push_to_azure_blob_storage:
                 requires: prefect-azure[blob_storage]
                 container: my-container
-                folder: my-project
+                folder: my-folder
                 credentials: "{{ prefect.blocks.azure-blob-storage-credentials.dev-credentials }}"
         ```
 
@@ -76,7 +76,7 @@ def push_to_azure_blob_storage(
             - prefect_azure.deployments.steps.push_to_azure_blob_storage:
                 requires: prefect-azure[blob_storage]
                 container: my-container
-                folder: my-project
+                folder: my-folder
                 credentials:
                     account_url: https://myaccount.blob.core.windows.net/
         ```
@@ -147,7 +147,7 @@ def pull_from_azure_blob_storage(
             - prefect_azure.deployments.steps.pull_from_azure_blob_storage:
                 requires: prefect-azure[blob_storage]
                 container: my-container
-                folder: my-project
+                folder: my-folder
                 credentials: "{{ prefect.blocks.azure-blob-storage-credentials.dev-credentials }}"
         ```
 
@@ -158,7 +158,7 @@ def pull_from_azure_blob_storage(
             - prefect_azure.deployments.steps.pull_from_azure_blob_storage:
                 requires: prefect-azure[blob_storage]
                 container: my-container
-                folder: my-project
+                folder: my-folder
                 credentials:
                     account_url: https://myaccount.blob.core.windows.net/
         ```

--- a/prefect_azure/projects/steps.py
+++ b/prefect_azure/projects/steps.py
@@ -33,7 +33,7 @@ For more information about using project steps, check out out the Prefect [docs]
 from pathlib import Path, PurePosixPath
 from typing import Dict, Optional
 
-from azure.identity import DefaultAzureCredential
+from azure.identity.aio import DefaultAzureCredential
 from azure.storage.blob import ContainerClient
 from prefect.utilities.filesystem import filter_files, relative_path_to_current_platform
 

--- a/prefect_azure/projects/steps.py
+++ b/prefect_azure/projects/steps.py
@@ -15,14 +15,14 @@ push and pull steps for the entire project, or they can be used in a project's
 
     push:
         - prefect_azure.projects.steps.push_project_to_azure_blob_storage:
-            requires: prefect-azure
+            requires: prefect-azure[blob_storage]
             container: my-container
             folder: my-project
             credentials: "{{ prefect.blocks.azure-blob-storage-credentials.dev-credentials }}"
 
     pull:
         - prefect_azure.projects.steps.pull_project_from_azure_blob_storage:
-            requires: prefect-azure
+            requires: prefect-azure[blob_storage]
             container: "{{ container }}"
             folder: "{{ folder }}"
             credentials: "{{ prefect.blocks.azure-blob-storage-credentials.dev-credentials }}"
@@ -63,7 +63,7 @@ def push_project_to_azure_blob_storage(
         ```yaml
         push:
             - prefect_azure.projects.steps.push_project_to_azure_blob_storage:
-                requires: prefect-azure
+                requires: prefect-azure[blob_storage]
                 container: my-container
                 folder: my-project
                 credentials: "{{ prefect.blocks.azure-blob-storage-credentials.dev-credentials }}"
@@ -74,7 +74,7 @@ def push_project_to_azure_blob_storage(
         ```yaml
         push:
             - prefect_azure.projects.steps.push_project_to_azure_blob_storage:
-                requires: prefect-azure
+                requires: prefect-azure[blob_storage]
                 container: my-container
                 folder: my-project
                 credentials:
@@ -145,7 +145,7 @@ def pull_project_from_azure_blob_storage(
         ```yaml
         pull:
             - prefect_azure.projects.steps.pull_project_from_azure_blob_storage:
-                requires: prefect-azure
+                requires: prefect-azure[blob_storage]
                 container: my-container
                 folder: my-project
                 credentials: "{{ prefect.blocks.azure-blob-storage-credentials.dev-credentials }}"
@@ -156,7 +156,7 @@ def pull_project_from_azure_blob_storage(
         ```yaml
         pull:
             - prefect_azure.projects.steps.pull_project_from_azure_blob_storage:
-                requires: prefect-azure
+                requires: prefect-azure[blob_storage]
                 container: my-container
                 folder: my-project
                 credentials:

--- a/prefect_azure/projects/steps.py
+++ b/prefect_azure/projects/steps.py
@@ -18,9 +18,9 @@ def push_project_to_azure_blob_storage(
     Args:
         container: The name of the container to push project files to
         folder: The folder within the container to push to
-        credentials: A dictionary of credentials with keys
-            `connection_string` or `account_url` and values of the corresponding
-            connection string or account url.
+        credentials: A dictionary of credentials with keys `connection_string` or
+            `account_url` and values of the corresponding connection string or
+            account url. If both are provided, `connection_string` will be used.
         ignore_file: The path to a file containing patterns of files to ignore when
             pushing to Azure Blob Storage. If not provided, the default `.prefectignore`
             file will be used.
@@ -103,9 +103,9 @@ def pull_project_from_azure_blob_storage(
     Args:
         container: The name of the container to pull project files from
         folder: The folder within the container to pull from
-        credentials: A dictionary of credentials with keys
-            `connection_string` or `account_url` and values of the corresponding
-            connection string or account url.
+        credentials: A dictionary of credentials with keys `connection_string` or
+            `account_url` and values of the corresponding connection string or
+            account url. If both are provided, `connection_string` will be used.
 
     Examples:
         Pull a project from an Azure Blob Storage container using credentials stored in
@@ -155,7 +155,7 @@ def pull_project_from_azure_blob_storage(
             )
             Path.mkdir(Path(target.parent), parents=True, exist_ok=True)
             with open(target, "wb") as f:
-                container_client.download_blob(blob).readinto(f)
+                client.download_blob(blob).readinto(f)
 
     return {
         "container": container,

--- a/prefect_azure/projects/steps.py
+++ b/prefect_azure/projects/steps.py
@@ -1,0 +1,164 @@
+from pathlib import Path, PurePosixPath
+from typing import Dict, Optional
+
+from azure.identity import DefaultAzureCredential
+from azure.storage.blob import ContainerClient
+from prefect.utilities.filesystem import filter_files, relative_path_to_current_platform
+
+
+def push_project_to_azure_blob_storage(
+    container: str,
+    folder: str,
+    credentials: Dict[str, str],
+    ignore_file: Optional[str] = ".prefectignore",
+):
+    """
+    Pushes a project to an Azure Blob Storage container.
+
+    Args:
+        container: The name of the container to push project files to
+        folder: The folder within the container to push to
+        credentials: A dictionary of credentials with keys
+            `connection_string` or `account_url` and values of the corresponding
+            connection string or account url.
+        ignore_file: The path to a file containing patterns of files to ignore when
+            pushing to Azure Blob Storage. If not provided, the default `.prefectignore`
+            file will be used.
+
+    Examples:
+        Push a project to an Azure Blob Storage container using credentials stored in a
+        block:
+        ```yaml
+        push:
+            - prefect_azure.projects.steps.push_project_to_azure_blob_storage:
+                requires: prefect-azure
+                container: my-container
+                folder: my-project
+                credentials: "{{ prefect.blocks.azure-blob-storage-credentials.dev-credentials }}"
+        ```
+
+        Push a project to an Azure Blob Storage container using an account URL and
+        default credentials:
+        ```yaml
+        push:
+            - prefect_azure.projects.steps.push_project_to_azure_blob_storage:
+                requires: prefect-azure
+                container: my-container
+                folder: my-project
+                credentials:
+                    account_url: https://myaccount.blob.core.windows.net/
+        ```
+    """  # noqa
+    local_path = Path.cwd()
+    if credentials.get("connection_string") is not None:
+        container_client = ContainerClient.from_connection_string(
+            credentials["connection_string"], container_name=container
+        )
+    elif credentials.get("account_url") is not None:
+        container_client = ContainerClient(
+            account_url=credentials["account_url"],
+            container_name=container,
+            credential=DefaultAzureCredential(),
+        )
+    else:
+        raise ValueError(
+            "Credentials must contain either connection_string or account_url"
+        )
+
+    included_files = None
+    if ignore_file and Path(ignore_file).exists():
+        with open(ignore_file, "r") as f:
+            ignore_patterns = f.readlines()
+
+        included_files = filter_files(str(local_path), ignore_patterns)
+
+    with container_client as client:
+        for local_file_path in local_path.expanduser().rglob("*"):
+            if (
+                included_files is not None
+                and str(local_file_path.relative_to(local_path)) not in included_files
+            ):
+                continue
+            elif not local_file_path.is_dir():
+                remote_file_path = Path(folder) / local_file_path.relative_to(
+                    local_path
+                )
+                with open(local_file_path, "rb") as f:
+                    client.upload_blob(str(remote_file_path), f, overwrite=True)
+
+    return {
+        "container": container,
+        "folder": folder,
+    }
+
+
+def pull_project_from_azure_blob_storage(
+    container: str,
+    folder: str,
+    credentials: Dict[str, str],
+):
+    """
+    Pulls a project from an Azure Blob Storage container.
+
+    Args:
+        container: The name of the container to pull project files from
+        folder: The folder within the container to pull from
+        credentials: A dictionary of credentials with keys
+            `connection_string` or `account_url` and values of the corresponding
+            connection string or account url.
+
+    Examples:
+        Pull a project from an Azure Blob Storage container using credentials stored in
+        a block:
+        ```yaml
+        pull:
+            - prefect_azure.projects.steps.pull_project_from_azure_blob_storage:
+                requires: prefect-azure
+                container: my-container
+                folder: my-project
+                credentials: "{{ prefect.blocks.azure-blob-storage-credentials.dev-credentials }}"
+        ```
+
+        Pull a project from an Azure Blob Storage container using an account URL and
+        default credentials:
+        ```yaml
+        pull:
+            - prefect_azure.projects.steps.pull_project_from_azure_blob_storage:
+                requires: prefect-azure
+                container: my-container
+                folder: my-project
+                credentials:
+                    account_url: https://myaccount.blob.core.windows.net/
+        ```
+    """  # noqa
+    local_path = Path.cwd()
+    if credentials.get("connection_string") is not None:
+        container_client = ContainerClient.from_connection_string(
+            credentials["connection_string"], container_name=container
+        )
+    elif credentials.get("account_url") is not None:
+        container_client = ContainerClient(
+            account_url=credentials["account_url"],
+            container_name=container,
+            credential=DefaultAzureCredential(),
+        )
+    else:
+        raise ValueError(
+            "Credentials must contain either connection_string or account_url"
+        )
+
+    with container_client as client:
+        for blob in client.list_blobs(name_starts_with=folder):
+            target = PurePosixPath(
+                local_path
+                / relative_path_to_current_platform(blob.name).relative_to(folder)
+            )
+            Path.mkdir(Path(target.parent), parents=True, exist_ok=True)
+            with open(target, "wb") as f:
+                container_client.download_blob(blob).readinto(f)
+
+    return {
+        "container": container,
+        "folder": folder,
+        "directory": local_path,
+    }

--- a/prefect_azure/projects/steps.py
+++ b/prefect_azure/projects/steps.py
@@ -1,3 +1,35 @@
+"""
+Prefect project steps for code storage and retrieval in Azure Blob Storage.
+
+These steps can be used in a project's `prefect.yaml` file to define the default 
+push and pull steps for the entire project, or they can be used in a project's 
+`deployment.yaml` file to define the push and pull steps for a specific deployment.
+
+!!! example
+    Sample `prefect.yaml` file that is configured to push and pull a
+    project to and from an Azure Blob Storage container:
+
+    ```yaml
+    prefect_version: ...
+    name: ...
+
+    push:
+        - prefect_azure.projects.steps.push_project_to_azure_blob_storage:
+            requires: prefect-azure
+            container: my-container
+            folder: my-project
+            credentials: "{{ prefect.blocks.azure-blob-storage-credentials.dev-credentials }}"
+
+    pull:
+        - prefect_azure.projects.steps.pull_project_from_azure_blob_storage:
+            requires: prefect-azure
+            container: "{{ container }}"
+            folder: "{{ folder }}"
+            credentials: "{{ prefect.blocks.azure-blob-storage-credentials.dev-credentials }}"
+    ```
+
+For more information about using project steps, check out out the Prefect [docs](https://docs.prefect.io/latest/concepts/projects/#the-prefect-yaml-file).
+"""  # noqa
 from pathlib import Path, PurePosixPath
 from typing import Dict, Optional
 
@@ -25,7 +57,7 @@ def push_project_to_azure_blob_storage(
             pushing to Azure Blob Storage. If not provided, the default `.prefectignore`
             file will be used.
 
-    Examples:
+    Example:
         Push a project to an Azure Blob Storage container using credentials stored in a
         block:
         ```yaml
@@ -107,7 +139,7 @@ def pull_project_from_azure_blob_storage(
             `account_url` and values of the corresponding connection string or
             account url. If both are provided, `connection_string` will be used.
 
-    Examples:
+    Example:
         Pull a project from an Azure Blob Storage container using credentials stored in
         a block:
         ```yaml

--- a/prefect_azure/workers/container_instance.py
+++ b/prefect_azure/workers/container_instance.py
@@ -501,6 +501,11 @@ class AzureContainerWorker(BaseWorker):
     job_configuration = AzureContainerJobConfiguration
     job_configuration_variables = AzureContainerVariables
 
+    _logo_url = "https://images.ctfassets.net/gm98wzqotmnx/6AiQ6HRIft8TspZH7AfyZg/39fd82bdbb186db85560f688746c8cdd/azure.png?h=250"  # noqa
+    _documentation_url = (
+        "https://prefecthq.github.io/prefect-azure/container_instance_worker/"
+    )
+
     async def run(
         self,
         flow_run: FlowRun,

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ extras_require["dev"] = dev_requires + extras_require["all_extras"]
 
 setup(
     name="prefect-azure",
-    description="Prefect tasks and subflows for interacting with Azure",
+    description="Prefect integrations with Microsoft Azure services",
     license="Apache License 2.0",
     author="Prefect Technologies, Inc.",
     author_email="help@prefect.io",

--- a/tests/projects/test_steps.py
+++ b/tests/projects/test_steps.py
@@ -1,0 +1,140 @@
+import os
+from pathlib import Path
+from unittest.mock import ANY, MagicMock, call
+
+import pytest
+from azure.identity import DefaultAzureCredential
+from azure.storage.blob import ContainerClient
+
+from prefect_azure.projects.steps import (
+    pull_project_from_azure_blob_storage,
+    push_project_to_azure_blob_storage,
+)
+
+
+@pytest.fixture
+def container_client_mock():
+    return MagicMock(spec=ContainerClient)
+
+
+@pytest.fixture
+def default_azure_credential_mock():
+    return MagicMock(spec=DefaultAzureCredential)
+
+
+@pytest.fixture
+def mock_azure_blob_storage(
+    monkeypatch, container_client_mock, default_azure_credential_mock
+):
+    monkeypatch.setattr(
+        "prefect_azure.projects.steps.ContainerClient",
+        container_client_mock,
+    )
+    monkeypatch.setattr(
+        "prefect_azure.projects.steps.DefaultAzureCredential",
+        default_azure_credential_mock,
+    )
+
+
+@pytest.fixture
+def tmp_files(tmp_path: Path):
+    files = [
+        "testfile1.txt",
+        "testfile2.txt",
+        "testfile3.txt",
+        "testdir1/testfile4.txt",
+        "testdir2/testfile5.txt",
+    ]
+
+    (tmp_path / ".prefectignore").write_text(
+        """
+    testdir1/*
+    .prefectignore
+    """
+    )
+
+    for file in files:
+        filepath = tmp_path / file
+        filepath.parent.mkdir(parents=True, exist_ok=True)
+        filepath.write_text("Sample text")
+
+    return tmp_path
+
+
+@pytest.mark.usefixtures("mock_azure_blob_storage")
+def test_push_project_to_azure_blob_storage_with_connection_string(
+    tmp_files: Path, container_client_mock: MagicMock
+):
+    container = "test-container"
+    folder = "test-folder"
+    credentials = {"connection_string": "fake_connection_string"}
+
+    os.chdir(tmp_files)
+
+    push_project_to_azure_blob_storage(container, folder, credentials)
+
+    container_client_mock.from_connection_string.assert_called_once_with(
+        credentials["connection_string"], container_name=container
+    )
+
+    upload_blob_mock = (
+        container_client_mock.from_connection_string.return_value.__enter__.return_value.upload_blob  # noqa
+    )
+
+    upload_blob_mock.assert_has_calls(
+        [
+            call(
+                f"{folder}/testfile1.txt",
+                ANY,
+                overwrite=True,
+            ),
+            call(
+                f"{folder}/testfile2.txt",
+                ANY,
+                overwrite=True,
+            ),
+            call(
+                f"{folder}/testfile3.txt",
+                ANY,
+                overwrite=True,
+            ),
+            call(
+                f"{folder}/testdir2/testfile5.txt",
+                ANY,
+                overwrite=True,
+            ),
+        ],
+        any_order=True,
+    )
+
+    assert all(
+        [
+            open(call.args[1].name).read() == "Sample text"
+            for call in upload_blob_mock.call_args_list
+        ]
+    )
+
+
+@pytest.mark.usefixtures("mock_azure_blob_storage")
+def test_pull_project_from_azure_blob_storage_with_connection_string(
+    tmp_path, container_client_mock
+):
+    container = "test-container"
+    folder = "test-folder"
+    credentials = {"connection_string": "fake_connection_string"}
+
+    blob_mock = MagicMock()
+    blob_mock.name = f"{folder}/sample_file.txt"
+
+    mock_context_client = (
+        container_client_mock.from_connection_string.return_value.__enter__.return_value
+    )
+    mock_context_client.list_blobs.return_value = [blob_mock]
+
+    pull_project_from_azure_blob_storage(container, folder, credentials)
+
+    mock_context_client.list_blobs.assert_called_once_with(name_starts_with=folder)
+    mock_context_client.download_blob.assert_called_once_with(blob_mock)
+
+    expected_file = tmp_path / "sample_file.txt"
+    assert expected_file.exists()

--- a/tests/projects/test_steps.py
+++ b/tests/projects/test_steps.py
@@ -110,8 +110,8 @@ class TestPushProject:
 
         assert all(
             [
-                open(call.args[1].name).read() == "Sample text"
-                for call in upload_blob_mock.call_args_list
+                open(call[1][1].name).read() == "Sample text"
+                for call in upload_blob_mock.mock_calls
             ]
         )
 
@@ -165,8 +165,8 @@ class TestPushProject:
 
         assert all(
             [
-                open(call.args[1].name).read() == "Sample text"
-                for call in upload_blob_mock.call_args_list
+                open(call[1][1].name).read() == "Sample text"
+                for call in upload_blob_mock.mock_calls
             ]
         )
 
@@ -238,8 +238,8 @@ class TestPushProject:
 
         assert all(
             [
-                open(call.args[1].name).read() == "Sample text"
-                for call in upload_blob_mock.call_args_list
+                open(call[1][1].name).read() == "Sample text"
+                for call in upload_blob_mock.mock_calls
             ]
         )
 


### PR DESCRIPTION
<!-- Thanks for contributing 🎉! Please ensure the title neatly summarizes the proposed changes. -->

<!-- Overview -->
- Adds `push_to_azure_blob_storage` and `pull_from_azure_blob_storage` project steps to allow Azure Blob Storage to be used for deployment storage and retrieval. New steps follow the pattern established for existing `push` and `pull` steps.
- Cleans up docstrings and field description for `AzureBlobStorageCredentials`
- Adds logo and documentation URLs to `AzureContainerWorker`

Closes #82 
Closes #83

### Example
<!-- A code blurb is best. Changes to features should include an example that is executable by a new user. -->
```yaml
prefect_version: ...
name: ...

push:
    - prefect_azure.deployments.steps.push_to_azure_blob_storage:
        requires: prefect-azure
        container: my-container
        folder: my-project
        credentials: "{{ prefect.blocks.azure-blob-storage-credentials.dev-credentials }}"

pull:
    - prefect_azure.deployments.steps.pull_from_azure_blob_storage:
        requires: prefect-azure
        container: "{{ container }}"
        folder: "{{ folder }}"
        credentials: "{{ prefect.blocks.azure-blob-storage-credentials.dev-credentials }}"
```

### Screenshots
<!--
Any relevant screenshots
  - The updated docs page from `mkdocs serve`.
  - Output from running the example.
  - Service integration test results.
-->
![localhost_8000_prefect-azure_deployments_steps_](https://github.com/PrefectHQ/prefect-azure/assets/12350579/1f45be93-67cb-4a22-b8fa-a3a02fdf2bc9)

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] References any related issue by including "Closes #<Issue Number>" or "Closes <Issue URL>".
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect-azure/issues/new/choose) first.
- [x] Includes tests or only affects documentation.
- [x] Passes `pre-commit` checks.
  - Run `pre-commit install && pre-commit run --all` locally for formatting and linting.
- [x] Includes screenshots of documentation updates.
  - Run `mkdocs serve` view documentation locally.
- [x] Summarizes PR's changes in [CHANGELOG.md](https://github.com/PrefectHQ/prefect-azure/blob/main/CHANGELOG.md)
