### PR TITLE
Add py.typed marker for PEP 561 compatibility 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ Made created containers have human-readable names with a randomized suffix.
 ### Fixed
 
 - Fixes bug where default Azure credentials could not be used - [#97](https://github.com/PrefectHQ/prefect-azure/pull/97)
-- Add py.typed marker to make the package PEP 561 compatible -[#11](https://github.com/PrefectHQ/prefect-azure/pull/100)
+- Add py.typed marker to make the package PEP 561 compatible -[#100 ](https://github.com/PrefectHQ/prefect-azure/pull/100)
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Made created containers have human-readable names with a randomized suffix.
 ### Fixed
 
 - Fixes bug where default Azure credentials could not be used - [#97](https://github.com/PrefectHQ/prefect-azure/pull/97)
+- Add py.typed marker to make the package PEP 561 compatible -[#11](https://github.com/PrefectHQ/prefect-azure/pull/100)
 
 ### Security
 


### PR DESCRIPTION
The library should declare itself as using types to static type checkers, as per PEP 561. That simply means adding this empty marker, as the code already makes use of types.

See https://mypy.readthedocs.io/en/stable/installed_packages.html#creating-pep-561-compatible-packages, and https://github.com/PrefectHQ/prefect/blob/main/src/prefect/py.typed for the corresponding file in the main prefect repo.

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [X] References any related issue by including "Closes #<Issue Number>" or "Closes <Issue URL>".
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect-azure/issues/new/choose) first.
- [X] Includes tests or only affects documentation.
- [X] Passes `pre-commit` checks.
  - Run `pre-commit install && pre-commit run --all` locally for formatting and linting.
- [X] Includes screenshots of documentation updates.
  - Run `mkdocs serve` view documentation locally.
- [x] Summarizes PR's changes in [CHANGELOG.md](https://github.com/PrefectHQ/prefect-azure/blob/main/CHANGELOG.md)
