### PR TITLE
Use aio version of credentials only with blob storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+## 0.2.10
+
+Released on June 22nd, 2023.
+
+### Fixed
+
+- Fixed credentials imports to ensure async credential classes are only used with async clients - [#106](https://github.com/PrefectHQ/prefect-azure/pull/106)
+
 ## 0.2.9
 
 Released on June 21st, 2023.

--- a/prefect_azure/credentials.py
+++ b/prefect_azure/credentials.py
@@ -3,7 +3,8 @@
 import functools
 from typing import TYPE_CHECKING, Any, Dict, Optional
 
-from azure.identity.aio import ClientSecretCredential, DefaultAzureCredential
+from azure.identity import ClientSecretCredential, DefaultAzureCredential
+from azure.identity.aio import DefaultAzureCredential as ADefaultAzureCredential
 from azure.mgmt.containerinstance import ContainerInstanceManagementClient
 from azure.mgmt.resource import ResourceManagementClient
 from pydantic import Field, SecretStr, root_validator
@@ -158,7 +159,7 @@ class AzureBlobStorageCredentials(Block):
         if self.connection_string is None:
             return BlobServiceClient(
                 account_url=self.account_url,
-                credential=DefaultAzureCredential(),
+                credential=ADefaultAzureCredential(),
             )
 
         return BlobServiceClient.from_connection_string(
@@ -202,7 +203,7 @@ class AzureBlobStorageCredentials(Block):
             return BlobClient(
                 account_url=self.account_url,
                 container_name=container,
-                credential=DefaultAzureCredential(),
+                credential=ADefaultAzureCredential(),
                 blob_name=blob,
             )
 
@@ -247,7 +248,7 @@ class AzureBlobStorageCredentials(Block):
             return ContainerClient(
                 account_url=self.account_url,
                 container_name=container,
-                credential=DefaultAzureCredential(),
+                credential=ADefaultAzureCredential(),
             )
 
         container_client = ContainerClient.from_connection_string(

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ prefect>=2.10.5
 azure_mgmt_containerinstance>=10.0
 azure_identity>=1.10
 azure-mgmt-resource>=21.2
+aiohttp
+

--- a/tests/test_aci_infrastructure.py
+++ b/tests/test_aci_infrastructure.py
@@ -7,7 +7,7 @@ import dateutil.parser
 import pytest
 from anyio.abc import TaskStatus
 from azure.core.exceptions import HttpResponseError, ResourceNotFoundError
-from azure.identity.aio import ClientSecretCredential, DefaultAzureCredential
+from azure.identity import ClientSecretCredential, DefaultAzureCredential
 from azure.mgmt.containerinstance.models import (
     EnvironmentVariable,
     ImageRegistryCredential,


### PR DESCRIPTION
<!-- Thanks for contributing 🎉! Please ensure the title neatly summarizes the proposed changes. -->

<!-- Overview -->
Attempts to fix an error where ACI workers aren't starting up correctly because the worker is attempting to use an `aio` version of the credentials classes with a sync version of the Container Instance client.

Closes #101 

### Example
<!-- A code blurb is best. Changes to features should include an example that is executable by a new user. -->

### Screenshots
<!--
Any relevant screenshots
  - The updated docs page from `mkdocs serve`.
  - Output from running the example.
  - Service integration test results.
-->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] References any related issue by including "Closes #<Issue Number>" or "Closes <Issue URL>".
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect-azure/issues/new/choose) first.
- [x] Includes tests or only affects documentation.
- [x] Passes `pre-commit` checks.
  - Run `pre-commit install && pre-commit run --all` locally for formatting and linting.
- [ ] Includes screenshots of documentation updates.
  - Run `mkdocs serve` view documentation locally.
- [x] Summarizes PR's changes in [CHANGELOG.md](https://github.com/PrefectHQ/prefect-azure/blob/main/CHANGELOG.md)
