### PR TITLE
Adds missing variables to pass base job template validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+## 0.2.12
+
+Released August 21st, 2023.
+
+### Fixed
+
+- Fixed misconfiguration in `AzureContainerWorker` base job template where `subnet_ids` and `dns_servers` were not included in the default base hob template variables - [#113](https://github.com/PrefectHQ/prefect-azure/pull/113/files)
+
 ## 0.2.11
 
 Released July 20th, 2023.

--- a/prefect_azure/workers/container_instance.py
+++ b/prefect_azure/workers/container_instance.py
@@ -471,6 +471,16 @@ class AzureContainerVariables(BaseVariables):
             "on the task definition."
         ),
     )
+    subnet_ids: Optional[List[str]] = Field(
+        title="Subnet IDs",
+        default=None,
+        description=("A list of subnet IDs to associate with the container group. "),
+    )
+    dns_servers: Optional[List[str]] = Field(
+        title="DNS Servers",
+        default=None,
+        description=("A list of DNS servers to associate with the container group."),
+    )
     aci_credentials: AzureContainerInstanceCredentials = Field(
         default_factory=AzureContainerInstanceCredentials,
         description=("The credentials to use to authenticate with Azure."),


### PR DESCRIPTION
<!-- Thanks for contributing 🎉! Please ensure the title neatly summarizes the proposed changes. -->

<!-- Overview -->
A fix to base job template validation in https://github.com/PrefectHQ/prefect/pull/10385 causes the default base job template for the ACI worker to fail validation. This would prevent any ACI work pools from being created. A hot fix for the `prefect-collection-registry` is in https://github.com/PrefectHQ/prefect-collection-registry/pull/278. This is the long term fix.

Closes

### Example
<!-- A code blurb is best. Changes to features should include an example that is executable by a new user. -->

### Screenshots
<!--
Any relevant screenshots
  - The updated docs page from `mkdocs serve`.
  - Output from running the example.
  - Service integration test results.
-->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] References any related issue by including "Closes #<Issue Number>" or "Closes <Issue URL>".
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect-azure/issues/new/choose) first.
- [ ] Includes tests or only affects documentation.
- [ ] Passes `pre-commit` checks.
  - Run `pre-commit install && pre-commit run --all` locally for formatting and linting.
- [ ] Includes screenshots of documentation updates.
  - Run `mkdocs serve` view documentation locally.
- [ ] Summarizes PR's changes in [CHANGELOG.md](https://github.com/PrefectHQ/prefect-azure/blob/main/CHANGELOG.md)
