### PR TITLE
pull_from_azure_blob_storage - Add check if blob destination target is a dir

### DIFF
--- a/prefect_azure/deployments/steps.py
+++ b/prefect_azure/deployments/steps.py
@@ -180,11 +180,16 @@ def pull_from_azure_blob_storage(
         )
 
     with container_client as client:
-        for blob in client.list_blobs(name_starts_with=folder):
+        for blob in client.list_blobs(name_starts_with=folder, ):
             target = PurePosixPath(
                 local_path
                 / relative_path_to_current_platform(blob.name).relative_to(folder)
             )
+            
+            # don't download a blob over a directory, otherwise it will error
+            if Path(target).is_dir():
+                continue
+            
             Path.mkdir(Path(target.parent), parents=True, exist_ok=True)
             with open(target, "wb") as f:
                 client.download_blob(blob).readinto(f)


### PR DESCRIPTION
list_blobs will return a size 0 record which represents a directory in ADLS2 hierarchical storage and error out. Check if the target is a directory and skip if it is.