### PR TITLE
Update deprecated docker module imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Updated imports of deprecated Prefect Docker modules, bumping the minimum required Prefect version to 2.10.11 - [#118](https://github.com/PrefectHQ/prefect-azure/pull/118)
+
 ### Deprecated
 
 ### Removed

--- a/prefect_azure/container_instance.py
+++ b/prefect_azure/container_instance.py
@@ -74,7 +74,7 @@ from typing import Dict, List, Optional, Union
 
 import anyio
 import dateutil.parser
-import prefect.infrastructure.docker
+import prefect.infrastructure.container
 from anyio.abc import TaskStatus
 from azure.core.exceptions import HttpResponseError, ResourceNotFoundError
 from azure.core.polling import LROPoller
@@ -95,10 +95,10 @@ from azure.mgmt.containerinstance.models import (
     ResourceRequirements,
     UserAssignedIdentities,
 )
-from prefect.docker import get_prefect_image_name
 from prefect.exceptions import InfrastructureNotAvailable, InfrastructureNotFound
 from prefect.infrastructure.base import Infrastructure, InfrastructureResult
 from prefect.utilities.asyncutils import run_sync_in_worker_thread, sync_compatible
+from prefect.utilities.dockerutils import get_prefect_image_name
 from pydantic import BaseModel, Field, SecretStr
 from slugify import slugify
 from typing_extensions import Literal
@@ -229,7 +229,7 @@ class AzureContainerInstanceJob(Infrastructure):
     )
     image_registry: Optional[
         Union[
-            prefect.infrastructure.docker.DockerRegistry,
+            prefect.infrastructure.container.DockerRegistry,
             ACRManagedIdentity,
         ]
     ] = Field(
@@ -587,7 +587,7 @@ class AzureContainerInstanceJob(Infrastructure):
     @staticmethod
     def _create_image_registry_credentials(
         image_registry: Union[
-            prefect.infrastructure.docker.DockerRegistry,
+            prefect.infrastructure.container.DockerRegistry,
             ACRManagedIdentity,
             None,
         ]
@@ -605,7 +605,7 @@ class AzureContainerInstanceJob(Infrastructure):
             input doesn't match any of the expected types.
         """
         if image_registry and isinstance(
-            image_registry, prefect.infrastructure.docker.DockerRegistry
+            image_registry, prefect.infrastructure.container.DockerRegistry
         ):
             return [
                 ImageRegistryCredential(

--- a/prefect_azure/workers/container_instance.py
+++ b/prefect_azure/workers/container_instance.py
@@ -90,11 +90,11 @@ from azure.mgmt.resource.resources.models import (
 )
 from prefect import get_client
 from prefect.client.schemas import FlowRun
-from prefect.docker import get_prefect_image_name
 from prefect.exceptions import InfrastructureNotAvailable, InfrastructureNotFound
 from prefect.server.schemas.core import Flow
 from prefect.server.schemas.responses import DeploymentResponse
 from prefect.utilities.asyncutils import run_sync_in_worker_thread
+from prefect.utilities.dockerutils import get_prefect_image_name
 from prefect.workers.base import (
     BaseJobConfiguration,
     BaseVariables,
@@ -210,7 +210,7 @@ class AzureContainerJobConfiguration(BaseJobConfiguration):
     entrypoint: Optional[str] = Field(default=DEFAULT_CONTAINER_ENTRYPOINT)
     image_registry: Optional[
         Union[
-            prefect.infrastructure.docker.DockerRegistry,
+            prefect.infrastructure.container.DockerRegistry,
             ACRManagedIdentity,
         ]
     ] = Field(default=None)
@@ -291,7 +291,7 @@ class AzureContainerJobConfiguration(BaseJobConfiguration):
     def _add_image_registry_credentials(
         self,
         image_registry: Union[
-            prefect.infrastructure.docker.DockerRegistry,
+            prefect.infrastructure.container.DockerRegistry,
             ACRManagedIdentity,
             None,
         ],
@@ -304,7 +304,7 @@ class AzureContainerJobConfiguration(BaseJobConfiguration):
             ACRManagedIdentity object.
         """
         if image_registry and isinstance(
-            image_registry, prefect.infrastructure.docker.DockerRegistry
+            image_registry, prefect.infrastructure.container.DockerRegistry
         ):
             self.arm_template["resources"][0]["properties"][
                 "imageRegistryCredentials"
@@ -426,7 +426,7 @@ class AzureContainerVariables(BaseVariables):
     )
     image_registry: Optional[
         Union[
-            prefect.infrastructure.docker.DockerRegistry,
+            prefect.infrastructure.container.DockerRegistry,
             ACRManagedIdentity,
         ]
     ] = Field(

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-prefect>=2.10.5
+prefect>=2.10.11
 azure_mgmt_containerinstance>=10.0
 azure_identity>=1.10
 azure-mgmt-resource>=21.2

--- a/tests/test_aci_infrastructure.py
+++ b/tests/test_aci_infrastructure.py
@@ -15,7 +15,7 @@ from azure.mgmt.containerinstance.models import (
 )
 from azure.mgmt.resource import ResourceManagementClient
 from prefect.exceptions import InfrastructureNotAvailable, InfrastructureNotFound
-from prefect.infrastructure.docker import DockerRegistry
+from prefect.infrastructure.container import DockerRegistry
 from prefect.settings import get_current_settings
 from pydantic import SecretStr
 

--- a/tests/test_aci_worker.py
+++ b/tests/test_aci_worker.py
@@ -16,7 +16,6 @@ from prefect.server.schemas.core import Flow
 from prefect.settings import get_current_settings
 from prefect.testing.utilities import AsyncMock
 from prefect.utilities.dockerutils import get_prefect_image_name
-
 from pydantic import VERSION as PYDANTIC_VERSION
 
 if PYDANTIC_VERSION.startswith("2."):

--- a/tests/test_aci_worker.py
+++ b/tests/test_aci_worker.py
@@ -10,12 +10,12 @@ from azure.core.exceptions import HttpResponseError, ResourceNotFoundError
 from azure.identity import ClientSecretCredential
 from azure.mgmt.resource import ResourceManagementClient
 from prefect.client.schemas import FlowRun
-from prefect.docker import get_prefect_image_name
 from prefect.exceptions import InfrastructureNotFound
-from prefect.infrastructure.docker import DockerRegistry
+from prefect.infrastructure.container import DockerRegistry
 from prefect.server.schemas.core import Flow
 from prefect.settings import get_current_settings
 from prefect.testing.utilities import AsyncMock
+from prefect.utilities.dockerutils import get_prefect_image_name
 from pydantic import SecretStr
 
 import prefect_azure.container_instance


### PR DESCRIPTION
Updates imports of the deprecated Docker modules to the new versions (introduced in https://github.com/PrefectHQ/prefect/pull/8788 & [Prefect 2.10.11](https://github.com/PrefectHQ/prefect/blob/main/RELEASE-NOTES.md#release-21011)):
- Change `prefect.infrastructure.docker` to `prefect.infrastructure.container`
- Change `prefect.docker` to `prefect.utilities.dockerutils`
- Bump minimum Prefect version to 2.10.11

### Checklist

- [ ] References any related issue by including "Closes #<Issue Number>" or "Closes <Issue URL>".
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect-azure/issues/new/choose) first.
- [x] Includes tests or only affects documentation.
- [x] Passes `pre-commit` checks.
  - Run `pre-commit install && pre-commit run --all` locally for formatting and linting.
- [ ] Includes screenshots of documentation updates.
  - Run `mkdocs serve` view documentation locally.
- [x] Summarizes PR's changes in [CHANGELOG.md](https://github.com/PrefectHQ/prefect-azure/blob/main/CHANGELOG.md)
