### PR TITLE
Explicitly state Subscription ID format

### DIFF
--- a/prefect_azure/credentials.py
+++ b/prefect_azure/credentials.py
@@ -414,7 +414,8 @@ class AzureMlCredentials(Block):
         default=..., description="The service principal password/key."
     )
     subscription_id: str = Field(
-        default=..., description="The Azure subscription ID containing the workspace, in UUID format: '00000000-0000-0000-0000-000000000000'."
+        default=...,
+        description="The Azure subscription ID containing the workspace, in format: '00000000-0000-0000-0000-000000000000'.",
     )
     resource_group: str = Field(
         default=..., description="The resource group containing the workspace."

--- a/prefect_azure/credentials.py
+++ b/prefect_azure/credentials.py
@@ -414,7 +414,7 @@ class AzureMlCredentials(Block):
         default=..., description="The service principal password/key."
     )
     subscription_id: str = Field(
-        default=..., description="The Azure subscription ID containing the workspace."
+        default=..., description="The Azure subscription ID containing the workspace, in UUID format: '00000000-0000-0000-0000-000000000000'."
     )
     resource_group: str = Field(
         default=..., description="The resource group containing the workspace."

--- a/prefect_azure/credentials.py
+++ b/prefect_azure/credentials.py
@@ -415,7 +415,7 @@ class AzureMlCredentials(Block):
     )
     subscription_id: str = Field(
         default=...,
-        description="The Azure subscription ID containing the workspace, in format: '00000000-0000-0000-0000-000000000000'.",
+        description="The Azure subscription ID containing the workspace, in format: '00000000-0000-0000-0000-000000000000'.",  # noqa
     )
     resource_group: str = Field(
         default=..., description="The resource group containing the workspace."


### PR DESCRIPTION
<!-- Thanks for contributing 🎉! Please ensure the title neatly summarizes the proposed changes. -->

<!-- Overview -->

Subscription ID format can at times be confusing, especially for those who've dealt with Azure Resource Manager. 

There is a `subscription.id` and a `subscriptionId`.


### Example
<!-- A code blurb is best. Changes to features should include an example that is executable by a new user. -->

From Azure docs:
https://learn.microsoft.com/en-us/azure/azure-resource-manager/templates/template-functions-scope#subscription

`subscription()` returns:

```
{
  "id": "/subscriptions/{subscription-id}",
  "subscriptionId": "{subscription-id}",
  ...
}
```

### Screenshots
<!--
Any relevant screenshots
  - The updated docs page from `mkdocs serve`.
  - Output from running the example.
  - Service integration test results.
-->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] References any related issue by including "Closes #<Issue Number>" or "Closes <Issue URL>".
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect-azure/issues/new/choose) first.
- [x] Includes tests or only affects documentation.
- [x] Passes `pre-commit` checks.
  - Run `pre-commit install && pre-commit run --all` locally for formatting and linting.
- [x] Includes screenshots of documentation updates.
  - Run `mkdocs serve` view documentation locally.
- [x] Summarizes PR's changes in [CHANGELOG.md](https://github.com/PrefectHQ/prefect-azure/blob/main/CHANGELOG.md)
