### PR TITLE
Add note on Hierarchical Namespace for Azure Storage Account

### DIFF
--- a/prefect_azure/deployments/steps.py
+++ b/prefect_azure/deployments/steps.py
@@ -28,6 +28,9 @@ define the push and pull steps for a specific deployment.
             credentials: "{{ prefect.blocks.azure-blob-storage-credentials.dev-credentials }}"
     ```
 
+!!! note
+    Azure Storage account needs to have Hierarchical Namespace disabled.
+
 For more information about using deployment steps, check out out the Prefect [docs](https://docs.prefect.io/latest/concepts/projects/#the-prefect-yaml-file).
 """  # noqa
 from pathlib import Path, PurePosixPath
@@ -138,6 +141,9 @@ def pull_from_azure_blob_storage(
         credentials: A dictionary of credentials with keys `connection_string` or
             `account_url` and values of the corresponding connection string or
             account url. If both are provided, `connection_string` will be used.
+
+    Note:
+        Azure Storage account needs to have Hierarchical Namespace disabled.
 
     Example:
         Pull from an Azure Blob Storage container using credentials stored in


### PR DESCRIPTION
Add note on Hierarchical Namespace for Azure Storage Account. I ran into a hard to understand issue since the code was being downloaded from a Blob Container with Hierarchical Namespace which meant that `.list_blobs()` had both the folder name and file name as seperate files it tried to download. An idea for another addition could be a check to see if the Storage Account has Hierarchical Namespace enabled before listing Blobs.

<!-- Thanks for contributing 🎉! Please ensure the title neatly summarizes the proposed changes. -->

<!-- Overview -->

Closes #126
Closes https://github.com/PrefectHQ/prefect/issues/11211

### Example
<!-- A code blurb is best. Changes to features should include an example that is executable by a new user. -->

### Screenshots
![image](https://github.com/PrefectHQ/prefect-azure/assets/44194839/0b02a53f-d9fc-42c3-bde2-bb59a2b042b1)

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] References any related issue by including "Closes #<Issue Number>" or "Closes <Issue URL>".
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect-azure/issues/new/choose) first.
- [ ] Includes tests or only affects documentation.
- [ ] Passes `pre-commit` checks.
  - Run `pre-commit install && pre-commit run --all` locally for formatting and linting.
- [ ] Includes screenshots of documentation updates.
  - Run `mkdocs serve` view documentation locally.
- [ ] Summarizes PR's changes in [CHANGELOG.md](https://github.com/PrefectHQ/prefect-azure/blob/main/CHANGELOG.md)
