### PR TITLE
Add `AzureBlobStorageContainer` block

### DIFF
--- a/prefect_azure/blob_storage.py
+++ b/prefect_azure/blob_storage.py
@@ -209,6 +209,8 @@ class AzureBlobStorageContainer(
 
     _block_type_name = "Azure Blob Storage Container"
     _logo_url = "https://cdn.sanity.io/images/3ugk85nk/production/54e3fa7e00197a4fbd1d82ed62494cb58d08c96a-250x250.png"  # noqa
+    _documentation_url = "https://prefecthq.github.io/prefect-azure/blob_storage/#prefect_azure.blob_storabe.AzureBlobStorageContainer"  # noqa
+
 
     container_name: str = Field(
         default=..., description="The name of a Azure Blob Storage container."
@@ -236,7 +238,10 @@ class AzureBlobStorageContainer(
 
     @sync_compatible
     async def download_folder_to_path(
-        self, from_folder: str, to_folder: str | Path, **download_kwargs: Dict[str, Any]
+        self,
+        from_folder: str,
+        to_folder: Union[str, Path],
+        **download_kwargs: Dict[str, Any],
     ) -> Coroutine[Any, Any, Path]:
         """Download a folder from the container to a local path.
 
@@ -347,7 +352,7 @@ class AzureBlobStorageContainer(
 
     @sync_compatible
     async def download_object_to_path(
-        self, from_path: str, to_path: str | Path, **download_kwargs: Dict[str, Any]
+        self, from_path: str, to_path: Union[str, Path], **download_kwargs: Dict[str, Any]
     ) -> Coroutine[Any, Any, Path]:
         """
         Downloads an object from a container to a specified path.
@@ -451,7 +456,7 @@ class AzureBlobStorageContainer(
 
     @sync_compatible
     async def upload_from_path(
-        self, from_path: str | Path, to_path: str, **upload_kwargs: Dict[str, Any]
+        self, from_path: Union[str, Path], to_path: str, **upload_kwargs: Dict[str, Any]
     ) -> Coroutine[Any, Any, str]:
         """
         Uploads an object from a local path to the specified destination path in the
@@ -494,12 +499,13 @@ class AzureBlobStorageContainer(
         async with self.credentials.get_blob_client(
             self.container_name, full_container_path
         ) as blob_client:
-            await blob_client.upload_blob(from_path, **upload_kwargs)
+            with open(from_path, "rb") as f:
+                await blob_client.upload_blob(f, **upload_kwargs)
         return to_path
 
     @sync_compatible
     async def upload_from_folder(
-        self, from_folder: str | Path, to_folder: str, **upload_kwargs: Dict[str, Any]
+        self, from_folder: Union[str, Path], to_folder: str, **upload_kwargs: Dict[str, Any]
     ) -> Coroutine[Any, Any, str]:
         """
         Uploads files from a local folder to a specified folder in the Azure
@@ -552,7 +558,7 @@ class AzureBlobStorageContainer(
                     async with container_client.get_blob_client(
                         blob_path.as_posix()
                     ) as blob_client:
-                        await blob_client.upload_blob(path.as_posix(), **upload_kwargs)
+                        await blob_client.upload_blob(path.read_bytes(), **upload_kwargs)
         return full_container_path
 
     @sync_compatible
@@ -560,7 +566,7 @@ class AzureBlobStorageContainer(
         self, from_path: str = None, local_path: str = None
     ) -> None:
         """
-        Downloads the contents of a directory from the blob storage to a local path.
+        Downloads the contents of a direry from the blob storage to a local path.
 
         Used to enable flow code storage for deployments.
 

--- a/prefect_azure/blob_storage.py
+++ b/prefect_azure/blob_storage.py
@@ -418,18 +418,18 @@ class AzureBlobStorageContainer(
         ) as blob_client:
             try:
                 blob_obj = await blob_client.download_blob(**download_kwargs)
+
+                path = Path(to_path)
+
+                path.parent.mkdir(parents=True, exist_ok=True)
+
+                with path.open(mode="wb") as to_file:
+                    await blob_obj.readinto(to_file)
             except ResourceNotFoundError as exc:
                 raise RuntimeError(
                     "An error occurred when attempting to download from container"
                     f" {self.container_name}: {exc.reason}"
                 ) from exc
-
-            path = Path(to_path)
-
-            path.parent.mkdir(parents=True, exist_ok=True)
-
-            with path.open(mode="wb") as to_file:
-                await blob_obj.readinto(to_file)
         return Path(to_path)
 
     @sync_compatible

--- a/prefect_azure/blob_storage.py
+++ b/prefect_azure/blob_storage.py
@@ -211,7 +211,6 @@ class AzureBlobStorageContainer(
     _logo_url = "https://cdn.sanity.io/images/3ugk85nk/production/54e3fa7e00197a4fbd1d82ed62494cb58d08c96a-250x250.png"  # noqa
     _documentation_url = "https://prefecthq.github.io/prefect-azure/blob_storage/#prefect_azure.blob_storabe.AzureBlobStorageContainer"  # noqa
 
-
     container_name: str = Field(
         default=..., description="The name of a Azure Blob Storage container."
     )
@@ -352,7 +351,10 @@ class AzureBlobStorageContainer(
 
     @sync_compatible
     async def download_object_to_path(
-        self, from_path: str, to_path: Union[str, Path], **download_kwargs: Dict[str, Any]
+        self,
+        from_path: str,
+        to_path: Union[str, Path],
+        **download_kwargs: Dict[str, Any],
     ) -> Coroutine[Any, Any, Path]:
         """
         Downloads an object from a container to a specified path.
@@ -505,7 +507,10 @@ class AzureBlobStorageContainer(
 
     @sync_compatible
     async def upload_from_folder(
-        self, from_folder: Union[str, Path], to_folder: str, **upload_kwargs: Dict[str, Any]
+        self,
+        from_folder: Union[str, Path],
+        to_folder: str,
+        **upload_kwargs: Dict[str, Any],
     ) -> Coroutine[Any, Any, str]:
         """
         Uploads files from a local folder to a specified folder in the Azure
@@ -558,7 +563,9 @@ class AzureBlobStorageContainer(
                     async with container_client.get_blob_client(
                         blob_path.as_posix()
                     ) as blob_client:
-                        await blob_client.upload_blob(path.read_bytes(), **upload_kwargs)
+                        await blob_client.upload_blob(
+                            path.read_bytes(), **upload_kwargs
+                        )
         return full_container_path
 
     @sync_compatible

--- a/prefect_azure/blob_storage.py
+++ b/prefect_azure/blob_storage.py
@@ -482,7 +482,7 @@ class AzureBlobStorageContainer(
                 await blob_client.upload_blob(from_file_object, **upload_kwargs)
             except ResourceNotFoundError as exc:
                 raise RuntimeError(
-                    "An error occurred when attempting to download from container"
+                    "An error occurred when attempting to upload from container"
                     f" {self.container_name}: {exc.reason}"
                 ) from exc
 
@@ -538,7 +538,7 @@ class AzureBlobStorageContainer(
                     await blob_client.upload_blob(f, **upload_kwargs)
             except ResourceNotFoundError as exc:
                 raise RuntimeError(
-                    "An error occurred when attempting to download from container"
+                    "An error occurred when attempting to upload to container"
                     f" {self.container_name}: {exc.reason}"
                 ) from exc
 
@@ -594,6 +594,8 @@ class AzureBlobStorageContainer(
         async with self.credentials.get_container_client(
             self.container_name
         ) as container_client:
+            if not Path(from_folder).is_dir():
+                raise ValueError(f"{from_folder} is not a directory")
             for path in Path(from_folder).rglob("*"):
                 if path.is_file():
                     blob_path = Path(full_container_path) / path.relative_to(
@@ -608,7 +610,7 @@ class AzureBlobStorageContainer(
                             )
                         except ResourceNotFoundError as exc:
                             raise RuntimeError(
-                                "An error occurred when attempting to download from "
+                                "An error occurred when attempting to upload to "
                                 f"container {self.container_name}: {exc.reason}"
                             ) from exc
         return full_container_path

--- a/prefect_azure/blob_storage.py
+++ b/prefect_azure/blob_storage.py
@@ -362,7 +362,8 @@ class AzureBlobStorageContainer(
             The path where the object was downloaded to.
 
         Example:
-            Download the object `object` from the container to the local path `file.txt`:
+            Download the object `object` from the container to the local path
+                `file.txt`:
 
             ```python
             from prefect_azure import AzureBlobStorageCredentials
@@ -404,7 +405,8 @@ class AzureBlobStorageContainer(
         self, from_file_object: BinaryIO, to_path: str, **upload_kwargs: Dict[str, Any]
     ) -> Coroutine[Any, Any, str]:
         """
-        Uploads an object from a file object to the specified path in the blob storage container.
+        Uploads an object from a file object to the specified path in the blob
+            storage container.
 
         Args:
             from_file_object: The file object to upload.
@@ -452,7 +454,8 @@ class AzureBlobStorageContainer(
         self, from_path: str | Path, to_path: str, **upload_kwargs: Dict[str, Any]
     ) -> Coroutine[Any, Any, str]:
         """
-        Uploads an object from a local path to the specified destination path in the blob storage container.
+        Uploads an object from a local path to the specified destination path in the
+            blob storage container.
 
         Args:
             from_path: The local path of the object to upload.
@@ -464,7 +467,8 @@ class AzureBlobStorageContainer(
             The destination path in the blob storage container.
 
         Example:
-            Upload a file from the local path `file.txt` to the container at the path `object`:
+            Upload a file from the local path `file.txt` to the container
+                at the path `object`:
 
             ```python
             from prefect_azure import AzureBlobStorageCredentials
@@ -498,7 +502,8 @@ class AzureBlobStorageContainer(
         self, from_folder: str | Path, to_folder: str, **upload_kwargs: Dict[str, Any]
     ) -> Coroutine[Any, Any, str]:
         """
-        Uploads files from a local folder to a specified folder in the Azure Blob Storage container.
+        Uploads files from a local folder to a specified folder in the Azure
+            Blob Storage container.
 
         Args:
             from_folder: The path to the local folder containing the files to upload.
@@ -510,7 +515,8 @@ class AzureBlobStorageContainer(
             The full path of the destination folder in the container.
 
         Example:
-            Upload the contents of the local folder `local_folder` to the container folder `folder`:
+            Upload the contents of the local folder `local_folder` to the container
+                folder `folder`:
 
             ```python
             from prefect_azure import AzureBlobStorageCredentials
@@ -574,9 +580,12 @@ class AzureBlobStorageContainer(
         Used to enable flow code storage for deployments.
 
         Args:
-            local_path: The local path of the directory to upload. Defaults to current directory.
-            to_path: The destination path in the blob storage. Defaults to root directory.
-            ignore_file: The path to a file containing patterns to ignore during upload.
+            local_path: The local path of the directory to upload. Defaults to
+                current directory.
+            to_path: The destination path in the blob storage. Defaults to
+                root directory.
+            ignore_file: The path to a file containing patterns to ignore
+                during upload.
         """
         to_path = "" if to_path is None else to_path
 

--- a/prefect_azure/blob_storage.py
+++ b/prefect_azure/blob_storage.py
@@ -1,15 +1,28 @@
-"""Tasks for interacting with Azure Blob Storage"""
+"""Integrations for interacting with Azure Blob Storage"""
+
+from io import BytesIO
+from pathlib import Path
 import uuid
-from typing import TYPE_CHECKING, List, Union
+from typing import TYPE_CHECKING, Any, BinaryIO, Coroutine, Dict, List, Optional, Union
 
 if TYPE_CHECKING:
     from azure.storage.blob import BlobProperties
 
 from prefect import task
 from prefect.logging import get_run_logger
+from prefect.blocks.abstract import ObjectStorageBlock
+from prefect.filesystems import WritableDeploymentStorage, WritableFileSystem
+from prefect.utilities.asyncutils import sync_compatible
+from pydantic import VERSION as PYDANTIC_VERSION
+from prefect.utilities.filesystem import filter_files
 
-if TYPE_CHECKING:
-    from prefect_azure.credentials import AzureBlobStorageCredentials
+if PYDANTIC_VERSION.startswith("2."):
+    from pydantic.v1 import Field
+else:
+    from pydantic import Field
+
+
+from prefect_azure.credentials import AzureBlobStorageCredentials
 
 
 @task
@@ -125,7 +138,7 @@ async def blob_storage_list(
     blob_storage_credentials: "AzureBlobStorageCredentials",
     name_starts_with: str = None,
     include: Union[str, List[str]] = None,
-    **kwargs
+    **kwargs,
 ) -> List["BlobProperties"]:
     """
     List objects from a given Blob Storage container.
@@ -177,3 +190,202 @@ async def blob_storage_list(
         ]
 
     return blobs
+
+
+class AzureBlobStorageContainer(
+    ObjectStorageBlock, WritableFileSystem, WritableDeploymentStorage
+):
+    _block_type_name = "Azure Blob Storage Container"
+    _logo_url = "https://cdn.sanity.io/images/3ugk85nk/production/54e3fa7e00197a4fbd1d82ed62494cb58d08c96a-250x250.png"
+
+    container_name: str = Field(
+        default=..., description="The name of a Azure Blob Storage container."
+    )
+    credentials: AzureBlobStorageCredentials = Field(
+        default_factory=AzureBlobStorageCredentials,
+        description="The credentials to use for authentication with Azure.",
+    )
+    base_folder: Optional[str] = Field(
+        default=None,
+        description=(
+            "A base path to a folder within the container to use "
+            "for reading and writing objects."
+        ),
+    )
+
+    def _get_path_relative_to_base_folder(self, path: Optional[str] = None) -> str:
+        if path is None and self.base_folder is None:
+            return ""
+        if path is None:
+            return self.base_folder
+        if self.base_folder is None:
+            return path
+        return (Path(self.base_folder) / Path(path)).as_posix()
+
+    @sync_compatible
+    async def download_folder_to_path(
+        self, from_folder: str, to_folder: str | Path, **download_kwargs: Dict[str, Any]
+    ) -> Coroutine[Any, Any, Path]:
+        logger = get_run_logger()
+        logger.info(
+            "Downloading folder from container %s to path %s",
+            self.container_name,
+            to_folder,
+        )
+        full_container_path = self._get_path_relative_to_base_folder(from_folder)
+        async with self.credentials.get_container_client(
+            self.container_name
+        ) as container_client:
+            async for blob in container_client.list_blobs(
+                name_starts_with=full_container_path
+            ):
+                blob_path = blob.name
+                local_path = Path(to_folder) / Path(blob_path).relative_to(
+                    full_container_path
+                )
+                local_path.parent.mkdir(parents=True, exist_ok=True)
+                async with container_client.get_blob_client(blob_path) as blob_client:
+                    blob_obj = await blob_client.download_blob()
+                    await blob_obj.download_to_path(local_path)
+        return Path(to_folder)
+
+    @sync_compatible
+    async def download_object_to_file_object(
+        self,
+        from_path: str,
+        to_file_object: BinaryIO,
+        **download_kwargs: Dict[str, Any],
+    ) -> Coroutine[Any, Any, BinaryIO]:
+        logger = get_run_logger()
+        logger.info(
+            "Downloading object from container %s to file object", self.container_name
+        )
+        full_container_path = self._get_path_relative_to_base_folder(from_path)
+        async with self.credentials.get_blob_client(
+            self.container_name, full_container_path
+        ) as blob_client:
+            blob_obj = await blob_client.download_blob()
+            await blob_obj.download_to_stream(to_file_object)
+        return to_file_object
+
+    @sync_compatible
+    async def download_object_to_path(
+        self, from_path: str, to_path: str | Path, **download_kwargs: Dict[str, Any]
+    ) -> Coroutine[Any, Any, Path]:
+        logger = get_run_logger()
+        logger.info(
+            "Downloading object from container %s to path %s",
+            self.container_name,
+            to_path,
+        )
+        full_container_path = self._get_path_relative_to_base_folder(from_path)
+        async with self.credentials.get_blob_client(
+            self.container_name, full_container_path
+        ) as blob_client:
+            blob_obj = await blob_client.download_blob()
+            await blob_obj.download_to_path(to_path)
+        return Path(to_path)
+
+    @sync_compatible
+    async def upload_from_file_object(
+        self, from_file_object: BinaryIO, to_path: str, **upload_kwargs: Dict[str, Any]
+    ) -> Coroutine[Any, Any, str]:
+        logger = get_run_logger()
+        logger.info(
+            "Uploading object to container %s with key %s", self.container_name, to_path
+        )
+        full_container_path = self._get_path_relative_to_base_folder(to_path)
+        async with self.credentials.get_blob_client(
+            self.container_name, full_container_path
+        ) as blob_client:
+            await blob_client.upload_blob(from_file_object, **upload_kwargs)
+        return to_path
+
+    @sync_compatible
+    async def upload_from_path(
+        self, from_path: str | Path, to_path: str, **upload_kwargs: Dict[str, Any]
+    ) -> Coroutine[Any, Any, str]:
+        logger = get_run_logger()
+        logger.info(
+            "Uploading object to container %s with key %s", self.container_name, to_path
+        )
+        full_container_path = self._get_path_relative_to_base_folder(to_path)
+        async with self.credentials.get_blob_client(
+            self.container_name, full_container_path
+        ) as blob_client:
+            await blob_client.upload_blob(from_path, **upload_kwargs)
+        return to_path
+
+    @sync_compatible
+    async def upload_from_folder(
+        self, from_folder: str | Path, to_folder: str, **upload_kwargs: Dict[str, Any]
+    ) -> Coroutine[Any, Any, str]:
+        logger = get_run_logger()
+        logger.info(
+            "Uploading folder to container %s with key %s",
+            self.container_name,
+            to_folder,
+        )
+        full_container_path = self._get_path_relative_to_base_folder(to_folder)
+        async with self.credentials.get_container_client(
+            self.container_name
+        ) as container_client:
+            for path in Path(from_folder).rglob("*"):
+                if path.is_file():
+                    blob_path = Path(full_container_path) / path.relative_to(
+                        from_folder
+                    )
+                    async with container_client.get_blob_client(
+                        blob_path.as_posix()
+                    ) as blob_client:
+                        await blob_client.upload_blob(path, **upload_kwargs)
+        return full_container_path
+
+    @sync_compatible
+    async def get_directory(
+        self, from_path: str = None, local_path: str = None
+    ) -> None:
+        await self.download_folder_to_path(from_path, local_path)
+
+    @sync_compatible
+    async def put_directory(
+        self, local_path: str = None, to_path: str = None, ignore_file: str = None
+    ) -> None:
+        to_path = "" if to_path is None else to_path
+
+        if local_path is None:
+            local_path = "."
+
+        included_files = None
+        if ignore_file:
+            with open(ignore_file, "r") as f:
+                ignore_patterns = f.readlines()
+
+            included_files = filter_files(local_path, ignore_patterns)
+
+        for local_file_path in Path(local_path).expanduser().rglob("*"):
+            if (
+                included_files is not None
+                and str(local_file_path.relative_to(local_path)) not in included_files
+            ):
+                continue
+            elif not local_file_path.is_dir():
+                remote_file_path = Path(to_path) / local_file_path.relative_to(
+                    local_path
+                )
+                with open(local_file_path, "rb") as local_file:
+                    local_file_content = local_file.read()
+
+                await self.write_path(
+                    remote_file_path.as_posix(), content=local_file_content
+                )
+
+    @sync_compatible
+    async def read_path(self, path: str) -> bytes:
+        file_obj = BytesIO()
+        await self.download_object_to_file_object(path, file_obj)
+        return file_obj.get_value()
+
+    @sync_compatible
+    async def write_path(self, path: str, content: bytes) -> None:
+        await self.upload_from_file_object(BytesIO(content), path)

--- a/prefect_azure/blob_storage.py
+++ b/prefect_azure/blob_storage.py
@@ -303,7 +303,8 @@ class AzureBlobStorageContainer(
                         await blob_obj.readinto(to_file)
             except ResourceNotFoundError as exc:
                 raise RuntimeError(
-                    f"An error occurred when atempting to download from container {self.container_name}: {exc.reason}"
+                    "An error occurred when attempting to download from container"
+                    f" {self.container_name}: {exc.reason}"
                 ) from exc
 
         return Path(to_folder)
@@ -360,7 +361,8 @@ class AzureBlobStorageContainer(
                 await blob_obj.download_to_stream(to_file_object)
             except ResourceNotFoundError as exc:
                 raise RuntimeError(
-                    f"An error occurred when atempting to download from container {self.container_name}: {exc.reason}"
+                    "An error occurred when attempting to download from container"
+                    f" {self.container_name}: {exc.reason}"
                 ) from exc
 
         return to_file_object
@@ -418,7 +420,8 @@ class AzureBlobStorageContainer(
                 blob_obj = await blob_client.download_blob(**download_kwargs)
             except ResourceNotFoundError as exc:
                 raise RuntimeError(
-                    f"An error occurred when atempting to download from container {self.container_name}: {exc.reason}"
+                    "An error occurred when attempting to download from container"
+                    f" {self.container_name}: {exc.reason}"
                 ) from exc
 
             path = Path(to_path)
@@ -479,7 +482,8 @@ class AzureBlobStorageContainer(
                 await blob_client.upload_blob(from_file_object, **upload_kwargs)
             except ResourceNotFoundError as exc:
                 raise RuntimeError(
-                    f"An error occurred when atempting to download from container {self.container_name}: {exc.reason}"
+                    "An error occurred when attempting to download from container"
+                    f" {self.container_name}: {exc.reason}"
                 ) from exc
 
         return to_path
@@ -534,7 +538,8 @@ class AzureBlobStorageContainer(
                     await blob_client.upload_blob(f, **upload_kwargs)
             except ResourceNotFoundError as exc:
                 raise RuntimeError(
-                    f"An error occurred when atempting to download from container {self.container_name}: {exc.reason}"
+                    "An error occurred when attempting to download from container"
+                    f" {self.container_name}: {exc.reason}"
                 ) from exc
 
         return to_path
@@ -603,7 +608,8 @@ class AzureBlobStorageContainer(
                             )
                         except ResourceNotFoundError as exc:
                             raise RuntimeError(
-                                f"An error occurred when atempting to download from container {self.container_name}: {exc.reason}"
+                                "An error occurred when attempting to download from "
+                                f"container {self.container_name}: {exc.reason}"
                             ) from exc
         return full_container_path
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,9 @@ import pytest
 from azure.core.exceptions import ResourceExistsError
 from prefect.testing.utilities import AsyncMock, prefect_test_harness
 
+from prefect_azure.credentials import AzureBlobStorageCredentials
+from azure.storage.blob.aio import BlobClient, BlobServiceClient, ContainerClient
+
 
 @pytest.fixture(scope="session", autouse=True)
 def prefect_db():
@@ -34,7 +37,10 @@ class AsyncIter:
             yield item
 
 
-mock_container = {"prefect.txt": b"prefect_works"}
+mock_container = {
+    "prefect.txt": b"prefect_works",
+    "folder/prefect.txt": b"prefect_works",
+}
 
 
 class BlobStorageClientMethodsMock:
@@ -53,13 +59,23 @@ class BlobStorageClientMethodsMock:
 
     async def download_blob(self):
         return AsyncMock(
-            content_as_bytes=AsyncMock(return_value=mock_container.get(self.blob))
+            name="blob_obj",
+            content_as_bytes=AsyncMock(return_value=mock_container.get(self.blob)),
+            download_to_stream=AsyncMock(
+                side_effect=lambda f: f.write(mock_container.get(self.blob))
+            ),
+            readinto=AsyncMock(
+                side_effect=lambda f: f.write(mock_container.get(self.blob))
+            ),
         )
 
-    async def upload_blob(self, data, overwrite):
+    async def upload_blob(self, data, overwrite=False):
         if not overwrite and self.blob in mock_container:
             raise ResourceExistsError("Cannot overwrite existing blob")
-        mock_container[self.blob] = data
+        if isinstance(data, (str, bytes)):
+            mock_container[self.blob] = data
+        else:
+            mock_container[self.blob] = data.read()
         return self.blob
 
     def list_blobs(self, name_starts_with=None, include=None, **kwargs):
@@ -94,6 +110,30 @@ def blob_storage_credentials():
     blob_storage_credentials.get_container_client.side_effect = (
         lambda container: BlobStorageClientMethodsMock()
     )
+    return blob_storage_credentials
+
+
+@pytest.fixture
+def mock_blob_storage_credentials():
+    blob_storage_credentials = AzureBlobStorageCredentials(connection_string="mock")
+    mock_get_blob_client_with_container = MagicMock(
+        side_effect=lambda container, blob: BlobStorageClientMethodsMock(blob)
+    )
+
+    blob_storage_credentials.get_blob_client = mock_get_blob_client_with_container
+
+    mock_get_blob_client_without_container = MagicMock(
+        side_effect=lambda blob: BlobStorageClientMethodsMock(blob)
+    )
+
+    blob_storage_credentials.get_container_client = MagicMock(spec=ContainerClient)
+    block_mock = MagicMock()
+    block_mock.name = "folder/prefect.txt"
+    blob_storage_credentials.get_container_client().__aenter__.return_value = AsyncMock(
+        list_blobs=MagicMock(return_value=AsyncIter([block_mock])),
+        get_blob_client=mock_get_blob_client_without_container,
+    )
+
     return blob_storage_credentials
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,10 +2,10 @@ from unittest.mock import MagicMock
 
 import pytest
 from azure.core.exceptions import ResourceExistsError
+from azure.storage.blob.aio import ContainerClient
 from prefect.testing.utilities import AsyncMock, prefect_test_harness
 
 from prefect_azure.credentials import AzureBlobStorageCredentials
-from azure.storage.blob.aio import BlobClient, BlobServiceClient, ContainerClient
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/tests/test_blob_storage.py
+++ b/tests/test_blob_storage.py
@@ -1,19 +1,17 @@
-from io import BytesIO
-from unittest.mock import AsyncMock, MagicMock, patch
 import uuid
+from io import BytesIO
+from pathlib import Path
 
 import pytest
 from azure.core.exceptions import ResourceExistsError
 from prefect import flow
-from pathlib import Path
 
 from prefect_azure.blob_storage import (
+    AzureBlobStorageContainer,
     blob_storage_download,
     blob_storage_list,
     blob_storage_upload,
-    AzureBlobStorageContainer,
 )
-from prefect_azure.credentials import AzureBlobStorageCredentials
 
 
 async def test_blob_storage_download_flow(blob_storage_credentials):

--- a/tests/test_blob_storage.py
+++ b/tests/test_blob_storage.py
@@ -1,14 +1,19 @@
+from io import BytesIO
+from unittest.mock import AsyncMock, MagicMock, patch
 import uuid
 
 import pytest
 from azure.core.exceptions import ResourceExistsError
 from prefect import flow
+from pathlib import Path
 
 from prefect_azure.blob_storage import (
     blob_storage_download,
     blob_storage_list,
     blob_storage_upload,
+    AzureBlobStorageContainer,
 )
+from prefect_azure.credentials import AzureBlobStorageCredentials
 
 
 async def test_blob_storage_download_flow(blob_storage_credentials):
@@ -111,3 +116,200 @@ async def test_blob_storage_list_flow_with_include(blob_storage_credentials):
     assert len(blobs) == 5
     for blob_data in blobs:
         assert isinstance(blob_data["metadata"], dict)
+
+
+class TestAzureBlobStorageContainer:
+    async def test_download_folder_to_path(
+        self, mock_blob_storage_credentials, tmp_path
+    ):
+        container = AzureBlobStorageContainer(
+            container_name="container",
+            credentials=mock_blob_storage_credentials,
+        )
+        await container.download_folder_to_path("folder", tmp_path / "folder")
+
+        assert (tmp_path / "folder").exists()
+        assert (tmp_path / "folder" / "prefect.txt").exists()
+        with open(tmp_path / "folder" / "prefect.txt", "rb") as f:
+            assert f.read() == b"prefect_works"
+
+    async def test_download_object_to_file_object(
+        self, mock_blob_storage_credentials, tmp_path
+    ):
+        container = AzureBlobStorageContainer(
+            container_name="container",
+            credentials=mock_blob_storage_credentials,
+        )
+        file_path = tmp_path / "file.txt"
+        with open(file_path, "wb") as f:
+            await container.download_object_to_file_object(
+                from_path="prefect.txt", to_file_object=f
+            )
+
+        assert file_path.exists()
+        with open(file_path, "rb") as f:
+            assert f.read() == b"prefect_works"
+
+    async def test_download_object_to_path(
+        self, mock_blob_storage_credentials, tmp_path
+    ):
+        container = AzureBlobStorageContainer(
+            container_name="container",
+            credentials=mock_blob_storage_credentials,
+        )
+        from_path = "prefect.txt"
+        to_path = tmp_path / "file.txt"
+
+        await container.download_object_to_path(from_path, to_path)
+
+        assert to_path.exists()
+        with open(to_path, "rb") as f:
+            assert f.read() == b"prefect_works"
+
+    async def test_upload_from_file_object(
+        self, mock_blob_storage_credentials, tmp_path
+    ):
+        container = AzureBlobStorageContainer(
+            container_name="container",
+            credentials=mock_blob_storage_credentials,
+        )
+        file_content = b"prefect_works_again"
+        file_object = BytesIO(file_content)
+        to_path = "object"
+
+        uploaded_path = await container.upload_from_file_object(
+            from_file_object=file_object,
+            to_path=to_path,
+        )
+
+        assert uploaded_path == to_path
+
+        await container.download_object_to_path("object", tmp_path / "file.txt")
+
+        with open(tmp_path / "file.txt", "rb") as f:
+            assert f.read() == b"prefect_works_again"
+
+    async def test_upload_from_path(self, mock_blob_storage_credentials, tmp_path):
+        container = AzureBlobStorageContainer(
+            container_name="container",
+            credentials=mock_blob_storage_credentials,
+        )
+        from_path = tmp_path / "file.txt"
+        to_path = "object-from-path"
+
+        with open(from_path, "wb") as f:
+            f.write(b"prefect_works_yet_again")
+
+        uploaded_path = await container.upload_from_path(
+            from_path=from_path,
+            to_path=to_path,
+        )
+
+        assert uploaded_path == to_path
+
+        await container.download_object_to_path(to_path, tmp_path / "file.txt")
+
+        with open(tmp_path / "file.txt", "rb") as f:
+            assert f.read() == b"prefect_works_yet_again"
+
+    async def test_upload_from_folder(
+        self, mock_blob_storage_credentials, tmp_path: Path
+    ):
+        container = AzureBlobStorageContainer(
+            container_name="container",
+            credentials=mock_blob_storage_credentials,
+        )
+        from_folder = tmp_path / "local_folder"
+        from_folder.mkdir(parents=True, exist_ok=True)
+        to_folder = "folder"
+
+        file1_path = from_folder / "file1.txt"
+        file2_path = from_folder / "file2.txt"
+        file1_path.write_bytes(b"file1_content")
+        file2_path.write_bytes(b"file2_content")
+
+        await container.upload_from_folder(
+            from_folder=from_folder,
+            to_folder=to_folder,
+        )
+
+        await container.download_object_to_path(
+            "folder/file1.txt", tmp_path / "read_file1.txt"
+        )
+
+        with open(tmp_path / "read_file1.txt", "rb") as f:
+            assert f.read() == b"file1_content"
+
+        await container.download_object_to_path(
+            "folder/file2.txt", tmp_path / "read_file2.txt"
+        )
+
+        with open(tmp_path / "read_file2.txt", "rb") as f:
+            assert f.read() == b"file2_content"
+
+    async def test_get_directory(slef, mock_blob_storage_credentials, tmp_path):
+        container = AzureBlobStorageContainer(
+            container_name="container",
+            credentials=mock_blob_storage_credentials,
+        )
+        from_path = "folder"
+        local_path = str(tmp_path / "local_directory")
+
+        await container.get_directory(from_path, local_path)
+
+        assert (tmp_path / "local_directory").exists()
+        assert (tmp_path / "local_directory" / "prefect.txt").exists()
+        with open(tmp_path / "local_directory" / "prefect.txt", "rb") as f:
+            assert f.read() == b"prefect_works"
+
+    async def test_put_directory(self, mock_blob_storage_credentials, tmp_path):
+        container = AzureBlobStorageContainer(
+            container_name="container",
+            credentials=mock_blob_storage_credentials,
+        )
+        local_path = tmp_path / "local_directory"
+        to_path = "destination_directory"
+
+        local_path.mkdir()
+        file1_path = local_path / "file1.txt"
+        file2_path = local_path / "file2.txt"
+        file1_path.write_bytes(b"file1_content")
+        file2_path.write_bytes(b"file2_content")
+
+        await container.put_directory(local_path=str(local_path), to_path=to_path)
+
+        await container.download_object_to_path(
+            "destination_directory/file1.txt", tmp_path / "read_file1.txt"
+        )
+        with open(tmp_path / "read_file1.txt", "rb") as f:
+            assert f.read() == b"file1_content"
+
+        await container.download_object_to_path(
+            "destination_directory/file2.txt", tmp_path / "read_file2.txt"
+        )
+        with open(tmp_path / "read_file2.txt", "rb") as f:
+            assert f.read() == b"file2_content"
+
+    async def test_read_path(self, mock_blob_storage_credentials):
+        container = AzureBlobStorageContainer(
+            container_name="container",
+            credentials=mock_blob_storage_credentials,
+        )
+        path = "file.txt"
+        file_content = b"prefect_works"
+        await container.upload_from_file_object(BytesIO(file_content), path)
+
+        result = await container.read_path(path)
+
+        assert result == file_content
+
+    async def test_blob_storage_write_path(self, mock_blob_storage_credentials):
+        container = AzureBlobStorageContainer(
+            container_name="prefect",
+            credentials=mock_blob_storage_credentials,
+        )
+        await container.write_path("prefect-write-path.txt", b"write_path_works")
+
+        result = await container.read_path("prefect-write-path.txt")
+
+        assert result == b"write_path_works"

--- a/tests/test_ml_datastore.py
+++ b/tests/test_ml_datastore.py
@@ -40,11 +40,11 @@ async def test_ml_get_datastore_flow_default(ml_credentials, datastore):
     assert result.datastore_name == "default"
 
 
-async def test_ml_upload_datastore_flow(ml_credentials, datastore):
+async def test_ml_upload_datastore_flow(ml_credentials, datastore, tmp_path):
     @flow
     async def ml_upload_datastore_flow():
         result = await ml_upload_datastore(
-            "tests/",
+            str(tmp_path),
             ml_credentials,
             target_path="target_path",
             overwrite=True,
@@ -52,25 +52,25 @@ async def test_ml_upload_datastore_flow(ml_credentials, datastore):
         return result
 
     result = await ml_upload_datastore_flow()
-    assert result["src_dir"] == "tests/"
+    assert result["src_dir"] == str(tmp_path)
     assert result["target_path"] == "target_path"
     assert result["overwrite"]
 
 
-async def test_ml_upload_datastore_flow_pathlib(ml_credentials, datastore):
+async def test_ml_upload_datastore_flow_pathlib(ml_credentials, datastore, tmp_path):
     @flow
     async def ml_upload_datastore_flow():
         result = await ml_upload_datastore(
-            Path("tests/"),
+            tmp_path,
             ml_credentials,
-            target_path=Path("target/path"),
+            target_path="target_path",
             overwrite=True,
         )
         return result
 
     result = await ml_upload_datastore_flow()
-    assert result["src_dir"] == "tests"
-    assert result["target_path"] == "target/path"
+    assert result["src_dir"] == str(tmp_path)
+    assert result["target_path"] == "target_path"
     assert result["overwrite"]
 
 

--- a/tests/test_ml_datastore.py
+++ b/tests/test_ml_datastore.py
@@ -1,5 +1,3 @@
-from pathlib import Path
-
 from prefect import flow
 
 from prefect_azure.ml_datastore import (


### PR DESCRIPTION
<!-- Thanks for contributing 🎉! Please ensure the title neatly summarizes the proposed changes. -->

<!-- Overview -->

Adds an `AzureBlobStorageContainer` block as a replacement for the `Azure` block in the core library. Works for both deployment flow code storage and result storage.

Closes https://github.com/PrefectHQ/prefect-azure/issues/135

### Example
<!-- A code blurb is best. Changes to features should include an example that is executable by a new user. -->

```python
from prefect_azure import AzureBlobStorageCredentials
from prefect_azure.blob_storage import AzureBlobStorageContainer

credentials = AzureBlobStorageCredentials(
    connection_string="connection_string",
)
container = AzureBlobStorageContainer(
    container_name="container",
    credentials=credentials,
)
# Downloads all files from the specified folder
container.download_folder_to_path(
    from_folder="folder",
    to_folder="local_folder"
)
```


### Screenshots
<!--
Any relevant screenshots
  - The updated docs page from `mkdocs serve`.
  - Output from running the example.
  - Service integration test results.
-->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] References any related issue by including "Closes #<Issue Number>" or "Closes <Issue URL>".
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect-azure/issues/new/choose) first.
- [x] Includes tests or only affects documentation.
- [x] Passes `pre-commit` checks.
  - Run `pre-commit install && pre-commit run --all` locally for formatting and linting.
- [ ] Includes screenshots of documentation updates.
  - Run `mkdocs serve` view documentation locally.
